### PR TITLE
Dim bright windows

### DIFF
--- a/picom.sample.conf
+++ b/picom.sample.conf
@@ -39,6 +39,8 @@ blur-background-exclude = [
 ];
 # opacity-rule = [ "80:class_g = 'URxvt'" ];
 
+# max-brightness = 0.66
+
 # Fading
 fading = true;
 # fade-delta = 30;

--- a/src/backend/backend.c
+++ b/src/backend/backend.c
@@ -251,6 +251,13 @@ void paint_all_new(session_t *ps, struct managed_win *t, bool ignore_damage) {
 			pixman_region32_fini(&reg_shadow);
 		}
 
+		// Set max brightness
+		if (ps->o.max_brightness < 1.0) {
+			ps->backend_data->ops->image_op(
+			    ps->backend_data, IMAGE_OP_MAX_BRIGHTNESS, w->win_image,
+			    NULL, &reg_visible, &ps->o.max_brightness);
+		}
+
 		// Draw window on target
 		if (!w->invert_color && !w->dim && w->frame_opacity == 1 && w->opacity == 1) {
 			ps->backend_data->ops->compose(ps->backend_data, w->win_image,

--- a/src/backend/backend.h
+++ b/src/backend/backend.h
@@ -47,6 +47,8 @@ enum image_operations {
 	// effective size. `reg_op` and `reg_visible` is ignored. `arg` is two integers,
 	// width and height, in that order.
 	IMAGE_OP_RESIZE_TILE,
+	// Limit how bright image can be
+	IMAGE_OP_MAX_BRIGHTNESS,
 };
 
 struct gaussian_blur_args {

--- a/src/backend/gl/gl_common.c
+++ b/src/backend/gl/gl_common.c
@@ -361,7 +361,9 @@ static void _gl_compose(backend_t *base, struct gl_image *img, GLuint target,
 		return;
 	}
 
-	GLuint brightness = gl_average_texture_color(base, img);
+	GLuint brightness = 0;
+	if (img->max_brightness < 1.0)
+		brightness = gl_average_texture_color(base, img);
 
 	assert(gd->win_shader.prog);
 	glUseProgram(gd->win_shader.prog);
@@ -381,7 +383,7 @@ static void _gl_compose(backend_t *base, struct gl_image *img, GLuint target,
 		glUniform1i(gd->win_shader.unifm_brightness, 1);
 	}
 	if (gd->win_shader.unifm_max_brightness >= 0) {
-		glUniform1f(gd->win_shader.unifm_max_brightness, 0.5); //TODO: parameterize
+		glUniform1f(gd->win_shader.unifm_max_brightness, (float)img->max_brightness);
 	}
 
 	// log_trace("Draw: %d, %d, %d, %d -> %d, %d (%d, %d) z %d\n",
@@ -1435,6 +1437,9 @@ bool gl_image_op(backend_t *base, enum image_operations op, void *image_data,
 		// texture is already set to repeat, so nothing else we need to do
 		tex->ewidth = iargs[0];
 		tex->eheight = iargs[1];
+		break;
+	case IMAGE_OP_MAX_BRIGHTNESS:
+		tex->max_brightness = *(double *)arg;
 		break;
 	}
 

--- a/src/backend/gl/gl_common.c
+++ b/src/backend/gl/gl_common.c
@@ -202,8 +202,6 @@ static void _gl_compose(backend_t *base, struct gl_image *img, GLuint target,
 		return;
 	}
 
-	bool dual_texture = false;
-
 	assert(gd->win_shader.prog);
 	glUseProgram(gd->win_shader.prog);
 	if (gd->win_shader.unifm_opacity >= 0) {
@@ -224,11 +222,6 @@ static void _gl_compose(backend_t *base, struct gl_image *img, GLuint target,
 
 	// Bind texture
 	glBindTexture(GL_TEXTURE_2D, img->inner->texture);
-	if (dual_texture) {
-		glActiveTexture(GL_TEXTURE1);
-		glBindTexture(GL_TEXTURE_2D, img->inner->texture);
-		glActiveTexture(GL_TEXTURE0);
-	}
 
 	GLuint vao;
 	glGenVertexArrays(1, &vao);
@@ -258,12 +251,6 @@ static void _gl_compose(backend_t *base, struct gl_image *img, GLuint target,
 	glBindTexture(GL_TEXTURE_2D, 0);
 	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
 	glDrawBuffer(GL_BACK);
-
-	if (dual_texture) {
-		glActiveTexture(GL_TEXTURE1);
-		glBindTexture(GL_TEXTURE_2D, 0);
-		glActiveTexture(GL_TEXTURE0);
-	}
 
 	glBindBuffer(GL_ARRAY_BUFFER, 0);
 	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);

--- a/src/backend/gl/gl_common.h
+++ b/src/backend/gl/gl_common.h
@@ -55,6 +55,7 @@ typedef struct gl_image {
 	struct gl_texture *inner;
 	double opacity;
 	double dim;
+	double max_brightness;
 	int ewidth, eheight;
 	bool has_alpha;
 	bool color_inverted;

--- a/src/backend/gl/gl_common.h
+++ b/src/backend/gl/gl_common.h
@@ -20,7 +20,14 @@ typedef struct {
 	GLint unifm_invert_color;
 	GLint unifm_tex;
 	GLint unifm_dim;
+	GLint unifm_brightness;
+	GLint unifm_max_brightness;
 } gl_win_shader_t;
+
+// Program and uniforms for brightness shader
+typedef struct {
+	GLuint prog;
+} gl_brightness_shader_t;
 
 // Program and uniforms for blur shader
 typedef struct {
@@ -60,6 +67,7 @@ struct gl_data {
 	// Height and width of the viewport
 	int height, width;
 	gl_win_shader_t win_shader;
+	gl_brightness_shader_t brightness_shader;
 	gl_fill_shader_t fill_shader;
 	GLuint back_texture, back_fbo;
 	GLuint present_prog;

--- a/src/backend/gl/glx.c
+++ b/src/backend/gl/glx.c
@@ -390,6 +390,7 @@ glx_bind_pixmap(backend_t *base, xcb_pixmap_t pixmap, struct xvisual_info fmt, b
 
 	log_trace("Binding pixmap %#010x", pixmap);
 	auto wd = ccalloc(1, struct gl_image);
+	wd->max_brightness = 1;
 	wd->inner = ccalloc(1, struct gl_texture);
 	wd->inner->width = wd->ewidth = r->width;
 	wd->inner->height = wd->eheight = r->height;

--- a/src/backend/xrender/xrender.c
+++ b/src/backend/xrender/xrender.c
@@ -458,6 +458,7 @@ static bool image_op(backend_t *base, enum image_operations op, void *image,
 		img->eheight = iargs[1];
 		break;
 	case IMAGE_OP_APPLY_ALPHA_ALL: assert(false);
+	case IMAGE_OP_MAX_BRIGHTNESS: assert(false);
 	}
 	pixman_region32_fini(&reg);
 	return true;

--- a/src/config.c
+++ b/src/config.c
@@ -549,6 +549,7 @@ char *parse_config(options_t *opt, const char *config_file, bool *shadow_enable,
 	    .inactive_dim_fixed = false,
 	    .invert_color_list = NULL,
 	    .opacity_rules = NULL,
+	    .max_brightness = 1.0,
 
 	    .use_ewmh_active_win = false,
 	    .focus_blacklist = NULL,

--- a/src/config.h
+++ b/src/config.h
@@ -210,6 +210,8 @@ typedef struct options {
 	c2_lptr_t *invert_color_list;
 	/// Rules to change window opacity.
 	c2_lptr_t *opacity_rules;
+	/// Limit window brightness
+	double max_brightness;
 
 	// === Focus related ===
 	/// Whether to try to detect WM windows and mark them as focused.

--- a/src/config_libconfig.c
+++ b/src/config_libconfig.c
@@ -422,6 +422,13 @@ char *parse_config_libconfig(options_t *opt, const char *config_file, bool *shad
 	}
 	// --use-damage
 	lcfg_lookup_bool(&cfg, "use-damage", &opt->use_damage);
+
+	// --max-brightness
+	if (config_lookup_float(&cfg, "max-brightness", &opt->max_brightness) && opt->use_damage) {
+		log_warn("max-brightness requires use-damage = false. Falling back to 1.0");
+		opt->max_brightness = 1.0;
+	}
+
 	// --glx-use-gpushader4
 	if (config_lookup_bool(&cfg, "glx-use-gpushader4", &ival) && ival) {
 		log_warn("glx-use-gpushader4 is deprecated since v6, please remove it "

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -1035,6 +1035,8 @@ static bool cdbus_process_opts_get(session_t *ps, DBusMessage *msg) {
 	cdbus_m_opts_get_do(inactive_dim, cdbus_reply_double);
 	cdbus_m_opts_get_do(inactive_dim_fixed, cdbus_reply_bool);
 
+	cdbus_m_opts_get_do(max_brightness, cdbus_reply_double);
+
 	cdbus_m_opts_get_do(use_ewmh_active_win, cdbus_reply_bool);
 	cdbus_m_opts_get_do(detect_transient, cdbus_reply_bool);
 	cdbus_m_opts_get_do(detect_client_leader, cdbus_reply_bool);

--- a/src/utils.c
+++ b/src/utils.c
@@ -32,4 +32,20 @@ void report_allocation_failure(const char *func, const char *file, unsigned int 
 	unreachable;
 }
 
+///
+/// Calculates next closest power of two of 32bit integer n
+/// ref: https://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
+///
+int next_power_of_two(int n)
+{
+	n--;
+	n |= n >> 1;
+	n |= n >> 2;
+	n |= n >> 4;
+	n |= n >> 8;
+	n |= n >> 16;
+	n++;
+	return n;
+}
+
 // vim: set noet sw=8 ts=8 :

--- a/src/utils.h
+++ b/src/utils.h
@@ -261,4 +261,12 @@ allocchk_(const char *func_name, const char *file, unsigned int line, void *ptr)
 	void name##_ref(type *a);                                                        \
 	void name##_unref(type **a);
 
+
+///
+/// Calculates next closest power of two of 32bit integer n
+/// ref: https://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
+///
+int next_power_of_two(int n);
+
+
 // vim: set noet sw=8 ts=8 :


### PR DESCRIPTION
Hey,

I have no idea if anybody is interested in this, so if You think it is useless for general case, just close this PR :wink:.

Anyway, I had this annoying problem, that when frequently switching between dark-themed windows and light-themed ones (especially when they take up most of the screen) there is no good screen brightness for both of them. Either dark-themed ones are too dark to comfortably look at them or light ones are too bright.

So I implemented this feature hoping to reduce that gap a bit by dimming windows depending on how bright they are.

Now initially I tried to implement this using mipmaps for brightness estimation, but there was significant CPU overhead on my computer (intel integrated GPU from 3rd gen processor, I also tested on 8th gen). What is more in order for them to work as expected, textures had to be scaled/padded in some way to power of two, this was somewhat inconvenient. So then I just decided to sample some pixels from texture in vertex shader, get an estimate on brightness, and pass it to fragment shader which can do the dimming. This, at least on my tests, did not incur any significant CPU or GPU load (during testing I used sample size of 40 for each dimension, so in total 1600 samples).

I also experimented a bit with different ways of estimating [lightness](https://en.wikipedia.org/wiki/HSL_and_HSV#Lightness), but I did not notice big differences on real windows, so I just left average for simplicity.

This works only on newer glx backend.
