### PR TITLE
Updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 picom
 =======
 
-**This is a development branch, bug to be expected**
+**This is a development branch, bugs to be expected**
 
-This is forked from the original Compton because that seems to have become unmaintained.
+This is forked from the original Compton because it seems to have become unmaintained.
 
 The current battle plan of this fork is to refactor it to make the code _possible_ to maintain, so potential contributors won't be scared away when they take a look at the code.
 
@@ -17,17 +17,17 @@ The original README can be found [here](README_orig.md)
 
 This flag enables the refactored/partially rewritten backends.
 
-Currently new backends features better vsync with the xrender backend, improved input lag with the glx backend (for non-NVIDIA users). The performance should be on par with the old backends.
+Currently, new backends feature better vsync with the xrender backend and improved input lag with the glx backend (for non-NVIDIA users). The performance should be on par with the old backends.
 
-New backend features will only be implemented on the new backends from now on, and the old backends will eventually be phased out after the new backends stabilizes.
+New backend features will only be implemented on the new backends from now on, and the old backends will eventually be phased out after the new backends stabilize.
 
-To test the new backends, add the `--experimental-backends` flag to the command line you used to run picom. This flag is not available from the configuration file.
+To test the new backends, add the `--experimental-backends` flag to the command you use to run picom. This flag is not available from the configuration file.
 
 To report issues with the new backends, please state explicitly you are using the new backends in your report.
 
 ## Rename
 
-### Rational
+### Rationale
 
 Since the inception of this fork, the existence of two compton repositories has caused some number of confusions. Mainly, people will report issues of this fork to the original compton, or report issues of the original compton here. Later, when distros started packaging this fork of compton, some wanted to differentiate the newer compton from the older version. They found themselves having no choice but to invent a name for this fork. This is less than ideal since this has the potential to cause more confusions among users.
 
@@ -39,9 +39,9 @@ The criteria for a good name were
 
 0. Being short, so it's easy to remember.
 1. Pronounceability, again, helps memorability
-2. Searchability, so when people searches the name, it's easy for them to find this repository.
+2. Searchability, so when people search the name, it's easy for them to find this repository.
 
-Of course, choosing a name is never easy, and there is no apparent way to objectively evaluate the names. Yet, we have to solve aforementioned problems as soon as possible.
+Of course, choosing a name is never easy, and there is no apparent way to objectively evaluate the names. Yet, we have to solve the aforementioned problems as soon as possible.
 
 In the end, we picked `picom` (a portmanteau of `pico` and `composite`) as our new name. This name might not be perfect, but is what we will move forward with unless there's a compelling reason not to.
 
@@ -49,7 +49,7 @@ In the end, we picked `picom` (a portmanteau of `pico` and `composite`) as our n
 
 Following the [deprecation process](https://github.com/yshui/picom/issues/114), migration to the new name will be broken into 3 steps:
 
-1. All mentions to `compton` will be updated to `picom` in the code base. `compton` will still be installed, but only as a symlink to `picom`. When `picom` is launched via the symlink, a warning message is printed, alerting the user to migrate. Similarly, the old configuration file names and dbus interface names will still be accepted but warned.
+1. All mentions of `compton` will be updated to `picom` in the code base. `compton` will still be installed, but only as a symlink to `picom`. When `picom` is launched via the symlink, a warning message is printed, alerting the user to migrate. Similarly, the old configuration file names and dbus interface names will still be accepted but warned.
 2. 3 major releases after step 1, the warning messages will be prompted to error messages and `picom` will not start when launched via the symlink.
 3. 3 major releases after step 2, the symlink will be removed.
 
@@ -134,7 +134,7 @@ Default install prefix is `/usr/local`, you can change it with `meson configure 
 
 ### Code
 
-You can look at the [Projects](https://github.com/yshui/picom/projects) page, and see if there is anything interests you. Or you can take a look at the [Issues](https://github.com/yshui/picom/issues).
+You can look at the [Projects](https://github.com/yshui/picom/projects) page, and see if there is anything that interests you. Or you can take a look at the [Issues](https://github.com/yshui/picom/issues).
 
 ### Non-code
 


### PR DESCRIPTION
Some (not particularly opinionated) grammar and spelling suggestions for the README.

Rationale for each change:
- "bug to be expected" -> "bugs to be expected". Usually the noun is plural in this expression (since more than one bug is likely to be found in the future).
- "because that seems to be unmaintained" -> "because it seems to be unmaintained". Using a demonstrative pronoun ("that") versus a personal pronoun ("it") suggests that we need to specify which of several Comptons is unmaintained.
- "features" -> "feature" and "stabilizes" -> "stabilize". The new backends are plural, should be conjugated without the trailing "s".
- "used" -> "use". The command used to launch picom has already been run. Changing to "use" indicates the command that habitually launches picom. Also changed "command line" (the interface, e.g. the prompt) to "command".
- "Rational" (adjective: based on reason) -> "Rationale" (noun: the reasons or logic that motivated an action)
- "when people searches" -> "when people search". Usually conjugated as plural [[1]](https://english.stackexchange.com/q/263046)
- "to solve aforementioned problems" -> "to solve the aforementioned problems". "Aforementioned" is preceded by a definite article when modifying a noun.
- "mentions to" (usually used in suggesting an 'honourable mention'/accolade regarding somebody) -> "mentions of" (instances of)