### PR TITLE
Unbreak next branch on FreeBSD

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -6,6 +6,7 @@ option('vsync_drm', type: 'boolean', value: false, description: 'Enable support 
 
 option('opengl', type: 'boolean', value: true, description: 'Enable features that require opengl (opengl backend, and opengl vsync methods)')
 option('dbus', type: 'boolean', value: true, description: 'Enable support for D-Bus remote control')
+option('inotify', type: 'boolean', value: true, description: 'Enable support for watching config changes')
 
 option('xrescheck', type: 'boolean', value: false, description: 'Enable X resource leak checker (for debug only)')
 

--- a/src/common.h
+++ b/src/common.h
@@ -154,8 +154,10 @@ typedef struct session {
 	void *backend_blur_context;
 	/// graphic drivers used
 	enum driver drivers;
+#ifdef CONFIG_INOTIFY
 	/// file watch handle
 	void *file_watch_handle;
+#endif
 	/// libev mainloop
 	struct ev_loop *loop;
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -9,7 +9,7 @@ base_deps = [
 
 srcs = [ files('picom.c', 'win.c', 'c2.c', 'x.c', 'config.c', 'vsync.c', 'utils.c',
                'diagnostic.c', 'string_utils.c', 'render.c', 'kernel.c', 'log.c',
-               'options.c', 'event.c', 'cache.c', 'atom.c', 'file_watch.c') ]
+               'options.c', 'event.c', 'cache.c', 'atom.c') ]
 picom_inc = include_directories('.')
 
 cflags = []
@@ -67,6 +67,14 @@ if get_option('dbus')
 	cflags += ['-DCONFIG_DBUS']
 	deps += [dependency('dbus-1', required: true)]
 	srcs += [ 'dbus.c' ]
+endif
+
+if get_option('inotify')
+	cflags += ['-DCONFIG_INOTIFY']
+	if not (host_machine.system() == 'linux')
+		deps += [dependency('libinotify', required: true)]
+	endif
+	srcs += [ 'file_watch.c' ]
 endif
 
 if get_option('xrescheck')

--- a/src/picom.c
+++ b/src/picom.c
@@ -54,7 +54,9 @@
 #endif
 #include "atom.h"
 #include "event.h"
+#ifdef CONFIG_INOTIFY
 #include "file_watch.h"
+#endif
 #include "list.h"
 #include "options.h"
 #include "uthash_extra.h"
@@ -1539,10 +1541,12 @@ static void exit_enable(EV_P attr_unused, ev_signal *w, int revents attr_unused)
 	quit(ps);
 }
 
+#ifdef CONFIG_INOTIFY
 static void config_file_change_cb(void *_ps) {
 	auto ps = (struct session *)_ps;
 	reset_enable(ps->loop, NULL, 0);
 }
+#endif
 
 /**
  * Initialize a session.
@@ -1942,10 +1946,12 @@ static session_t *session_init(int argc, char **argv, Display *dpy,
 		exit(0);
 	}
 
+#ifdef CONFIG_INOTIFY
 	ps->file_watch_handle = file_watch_init(ps->loop);
 	if (ps->file_watch_handle && config_file) {
 		file_watch_add(ps->file_watch_handle, config_file, config_file_change_cb, ps);
 	}
+#endif
 
 	free(config_file_to_free);
 
@@ -2112,8 +2118,10 @@ static void session_destroy(session_t *ps) {
 		unredirect(ps);
 	}
 
+#ifdef CONFIG_INOTIFY
 	file_watch_destroy(ps->loop, ps->file_watch_handle);
 	ps->file_watch_handle = NULL;
+#endif
 
 	// Stop listening to events on root window
 	xcb_change_window_attributes(ps->c, ps->root, XCB_CW_EVENT_MASK,


### PR DESCRIPTION
inotify only exists on Linux, see [error log](https://github.com/yshui/picom/files/3829208/picom-n.141.log). BSDs can use [libinotify-kqueue](https://github.com/libinotify-kqueue/libinotify-kqueue) but it wouldn't help Solaris and some other systems supported by Xorg server.
