### PR TITLE
Create picom-dbus.desktop

### DIFF
--- a/picom-dbus.desktop
+++ b/picom-dbus.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=picom (dbus)
+GenericName=X compositor (dbus)
+Comment=A X compositor with dbus backend enabled
+Categories=Utility;
+Keywords=compositor;composite manager;window effects;transparency;opacity;
+TryExec=picom
+Exec=picom --dbus


### PR DESCRIPTION
This is mostly for use by session managers that want to start picom with dbus enabled at login.