### PR TITLE
Reduce quequotions in CONTRIBUTORS

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -35,7 +35,6 @@ Patrick Collins <Patricol@users.noreply.github.com>
 Peter Mattern <matternp@arcor.de>
 Phil Blundell <pb@reciva.com>
 Que Quotion <quequotion@bugmenot.com>
-quequotion <the_q123@hotmail.com>
 Richard Grenville <pyxlcy@gmail.com>
 Scott Leggett <scott@sl.id.au>
 Tasos Sahanidis <tasos@tasossah.com>


### PR DESCRIPTION
That other quequotion is also me; I prefer the "full name" and bugmenot address.