### PR TITLE
Try to unbreak build on DragonFly

### DIFF
--- a/src/compiler.h
+++ b/src/compiler.h
@@ -94,7 +94,11 @@
 # define unreachable do {} while(0)
 #endif
 
-#ifndef __STDC_NO_THREADS__
+#ifndef __has_include
+# define __has_include(x) 0
+#endif
+
+#if !defined(__STDC_NO_THREADS__) && __has_include(<threads.h>)
 # include <threads.h>
 #elif __STDC_VERSION__ >= 201112L
 # define thread_local _Thread_local


### PR DESCRIPTION
DragonFly and OpenBSD neither support C11 threads nor define `__STDC_NO_THREADS__`. [According](https://codesearch.debian.net/search?q=__STDC_NO_THREADS__) to Debian `__STDC_NO_THREADS__` usage is uncommon, mostly limited to GNU libc.

https://sting.dragonflybsd.org/dports/logs/x11-wm___picom.log
