### PR TITLE
picom: Drop libxdg-basedir

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ Assuming you already have all the usual building tools installed (e.g. gcc, pyth
 * pixman
 * libdbus (optional, disable with the `-Ddbus=false` meson configure flag)
 * libconfig (optional, disable with the `-Dconfig_file=false` meson configure flag)
-* libxdg-basedir (optional, disable with the `-Dconfig_file=false` meson configure flag)
 * libGL (optional, disable with the `-Dopengl=false` meson configure flag)
 * libpcre (optional, disable with the `-Dregex=false` meson configure flag)
 * libev
@@ -92,7 +91,7 @@ Assuming you already have all the usual building tools installed (e.g. gcc, pyth
 On Debian based distributions (e.g. Ubuntu), the list of needed packages are
 
 ```
-libxext-dev libxcb1-dev libxcb-damage0-dev libxcb-xfixes0-dev libxcb-shape0-dev libxcb-render-util0-dev libxcb-render0-dev libxcb-randr0-dev libxcb-composite0-dev libxcb-image0-dev libxcb-present-dev libxcb-xinerama0-dev libpixman-1-dev libdbus-1-dev libconfig-dev libxdg-basedir-dev libgl1-mesa-dev  libpcre2-dev  libevdev-dev uthash-dev libev-dev libx11-xcb-dev
+libxext-dev libxcb1-dev libxcb-damage0-dev libxcb-xfixes0-dev libxcb-shape0-dev libxcb-render-util0-dev libxcb-render0-dev libxcb-randr0-dev libxcb-composite0-dev libxcb-image0-dev libxcb-present-dev libxcb-xinerama0-dev libpixman-1-dev libdbus-1-dev libconfig-dev libgl1-mesa-dev  libpcre2-dev  libevdev-dev uthash-dev libev-dev libx11-xcb-dev
 ```
 
 To build the documents, you need `asciidoc`

--- a/src/config_libconfig.c
+++ b/src/config_libconfig.c
@@ -6,7 +6,6 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <basedir_fs.h>
 #include <libconfig.h>
 #include <libgen.h>
 
@@ -35,6 +34,46 @@ static inline int lcfg_lookup_bool(const config_t *config, const char *path, boo
 		*value = ival;
 
 	return ret;
+}
+
+const char *xdgConfigHome(void) {
+	char *xdgh = getenv("XDG_CONFIG_HOME");
+	char *home = getenv("HOME");
+
+	if (!xdgh) {
+		if (!home) return NULL;
+
+		xdgh = cvalloc(strlen(home) + 8 + 1);
+
+		strcpy(xdgh, home);
+		strcat(xdgh, "/.config");
+	}
+
+	return xdgh;
+}
+
+const char * const * xdgConfigDirectories(void) {
+	char *dirs, *path, *xdgd = getenv("XDG_CONFIG_DIRS");
+	char **dir_list = {0};
+	unsigned int sep = 0;
+
+	if (!xdgd) xdgd = ":/etc/xdg:";
+
+	dirs = strdup(xdgd);
+	CHECK(dirs != NULL);
+	path = strtok(dirs, ":");
+
+	while (path) {
+		dir_list = realloc(dir_list, sizeof(char*) * ++sep);
+
+		CHECK(dir_list);
+
+		dir_list[sep-1] = path;
+
+		path = strtok(NULL, ":");
+	}
+
+	return (const char * const *)dir_list;
 }
 
 /// Search for config file under a base directory
@@ -78,7 +117,7 @@ FILE *open_config_file(const char *cpath, char **ppath) {
 	}
 
 	// First search for config file in user config directory
-	auto config_home = xdgConfigHome(NULL);
+	auto config_home = xdgConfigHome();
 	auto ret = open_config_file_at(config_home, ppath);
 	free((void *)config_home);
 	if (ret) {
@@ -101,7 +140,7 @@ FILE *open_config_file(const char *cpath, char **ppath) {
 	}
 
 	// Fall back to config file in system config directory
-	auto config_dirs = xdgConfigDirectories(NULL);
+	auto config_dirs = xdgConfigDirectories();
 	for (int i = 0; config_dirs[i]; i++) {
 		ret = open_config_file_at(config_dirs[i], ppath);
 		if (ret) {

--- a/src/meson.build
+++ b/src/meson.build
@@ -38,8 +38,8 @@ endif
 deps = []
 
 if get_option('config_file')
-	deps += [dependency('libconfig', version: '>=1.4', required: true),
-	         dependency('libxdg-basedir', required: true)]
+	deps += [dependency('libconfig', version: '>=1.4', required: true)]
+
 	cflags += ['-DCONFIG_LIBCONFIG']
 	srcs += [ 'config_libconfig.c' ]
 endif


### PR DESCRIPTION
This PR drops libxdg-basedir. 

I've implemented this in a way which avoids touching the existing code. It merely implements two functions to provide the same functionality provided by `libxdg-basedir` of which picom hardly used in the first place.

C isn't my forte so let me know if there are any issues. I also didn't try to adhere to the existing style as I'm sure there will be nitpicks about the code itself prior anyway. NOTE: I'm not freeing any memory as I believe picom does this itself afterwards(?). Let me know and I'll fix it.

Thanks

Closes #91 