### PR TITLE
Invert script optimizations 

### DIFF
--- a/dbus-examples/inverter.sh
+++ b/dbus-examples/inverter.sh
@@ -9,7 +9,7 @@ stderr() {
 # === Verify `compton --dbus` status ===
 
 if [ -z "$(dbus-send --session --dest=org.freedesktop.DBus --type=method_call --print-reply /org/freedesktop/DBus org.freedesktop.DBus.ListNames | grep compton)" ]; then
-  stderr "compton DBus interface unavailable"
+  stderr "picom DBus interface unavailable"
   if [ -n "$(pgrep picom)" ]; then
     stderr "picom running without dbus interface"
     #killall picom & # Causes all windows to flicker away and come back ugly.

--- a/dbus-examples/inverter.sh
+++ b/dbus-examples/inverter.sh
@@ -6,14 +6,14 @@ stderr() {
   printf "\033[1;31m%s\n\033[0m" "$@" >&2
 }
 
-# === Verify `compton --dbus` status ===
+# === Verify `picom --dbus` status ===
 
 if [ -z "$(dbus-send --session --dest=org.freedesktop.DBus --type=method_call --print-reply /org/freedesktop/DBus org.freedesktop.DBus.ListNames | grep compton)" ]; then
   stderr "picom DBus interface unavailable"
   if [ -n "$(pgrep picom)" ]; then
     stderr "picom running without dbus interface"
     #killall picom & # Causes all windows to flicker away and come back ugly.
-    #compton --dbus & # Causes all windows to flicker away and come back beautiful
+    #picom --dbus & # Causes all windows to flicker away and come back beautiful
   else
     stderr "picom not running"
   fi
@@ -46,7 +46,7 @@ if [ -z "$1" -o "$1" = "selected" ]; then
   window=$(xwininfo -frame | sed -n 's/^xwininfo: Window id: \(0x[[:xdigit:]][[:xdigit:]]*\).*/\1/p') # Select window by mouse
 elif [ "$1" = "focused" ]; then
   # Ensure we are tracking focus
-  window=$(${picom_dbus}find_win string:focused | $SED -n 's/^[[:space:]]*'${type_win}'[[:space:]]*\([[:digit:]]*\).*/\1/p') # Query compton for the active window
+  window=$(${picom_dbus}find_win string:focused | $SED -n 's/^[[:space:]]*'${type_win}'[[:space:]]*\([[:digit:]]*\).*/\1/p') # Query picom for the active window
 elif echo "$1" | grep -Eiq '^([[:digit:]][[:digit:]]*|0x[[:xdigit:]][[:xdigit:]]*)$'; then
   window="$1" # Accept user-specified window-id if the format is correct
 else

--- a/dbus-examples/inverter.sh
+++ b/dbus-examples/inverter.sh
@@ -29,7 +29,7 @@ SED="${SED:-$(command -v gsed || printf 'sed')}"
 dpy=$(printf "$DISPLAY" | tr -c '[:alnum:]' _)
 
 if [ -z "$dpy" ]; then
-  echo "Cannot find display."
+  stderr "Cannot find display."
   exit 1
 fi
 

--- a/dbus-examples/inverter.sh
+++ b/dbus-examples/inverter.sh
@@ -1,38 +1,41 @@
 #!/bin/sh
 
+# == Declare stderr function ===
+
+stderr() {
+  printf "\033[1;31m%s\n\033[0m" "$@" >&2
+}
+
 # === Verify `compton --dbus` status ===
 
-if [ -z "`dbus-send --session --dest=org.freedesktop.DBus --type=method_call --print-reply /org/freedesktop/DBus org.freedesktop.DBus.ListNames | grep compton`" ]; then
-  echo "compton DBus interface unavailable"
-  if [ -n "`pgrep picom`" ]; then
-    echo "compton running without dbus interface"
-    #killall compton & # Causes all windows to flicker away and come back ugly.
+if [ -z "$(dbus-send --session --dest=org.freedesktop.DBus --type=method_call --print-reply /org/freedesktop/DBus org.freedesktop.DBus.ListNames | grep compton)" ]; then
+  stderr "compton DBus interface unavailable"
+  if [ -n "$(pgrep picom)" ]; then
+    stderr "picom running without dbus interface"
+    #killall picom & # Causes all windows to flicker away and come back ugly.
     #compton --dbus & # Causes all windows to flicker away and come back beautiful
   else
-    echo "compton not running"
+    stderr "picom not running"
   fi
-  exit 1;
+  exit 1
 fi
 
 # === Setup sed ===
 
-if [ -z "$SED" ]; then
-  SED="sed"
-  command -v gsed > /dev/null && SED="gsed"
-fi
+SED="${SED:-$(command -v gsed || printf 'sed')}"
 
 # === Get connection parameters ===
 
-dpy=$(echo -n "$DISPLAY" | tr -c '[:alnum:]' _)
+dpy=$(printf "$DISPLAY" | tr -c '[:alnum:]' _)
 
 if [ -z "$dpy" ]; then
   echo "Cannot find display."
-  exit 1;
+  exit 1
 fi
 
 service="com.github.chjj.compton.${dpy}"
 interface="com.github.chjj.compton"
-compton_dbus="dbus-send --print-reply --dest="${service}" / "${interface}"."
+picom_dbus="dbus-send --print-reply --dest="${service}" / "${interface}"."
 type_win='uint32'
 type_enum='uint32'
 
@@ -43,7 +46,7 @@ if [ -z "$1" -o "$1" = "selected" ]; then
   window=$(xwininfo -frame | sed -n 's/^xwininfo: Window id: \(0x[[:xdigit:]][[:xdigit:]]*\).*/\1/p') # Select window by mouse
 elif [ "$1" = "focused" ]; then
   # Ensure we are tracking focus
-  window=$(${compton_dbus}find_win string:focused | $SED -n 's/^[[:space:]]*'${type_win}'[[:space:]]*\([[:digit:]]*\).*/\1/p') # Query compton for the active window
+  window=$(${picom_dbus}find_win string:focused | $SED -n 's/^[[:space:]]*'${type_win}'[[:space:]]*\([[:digit:]]*\).*/\1/p') # Query compton for the active window
 elif echo "$1" | grep -Eiq '^([[:digit:]][[:digit:]]*|0x[[:xdigit:]][[:xdigit:]]*)$'; then
   window="$1" # Accept user-specified window-id if the format is correct
 else
@@ -52,15 +55,15 @@ fi
 
 # Color invert the selected or focused window
 if [ -n "$window" ]; then
-  invert_status="$(${compton_dbus}win_get "${type_win}:${window}" string:invert_color | $SED -n 's/^[[:space:]]*boolean[[:space:]]*\([[:alpha:]]*\).*/\1/p')"
+  invert_status="$(${picom_dbus}win_get "${type_win}:${window}" string:invert_color | $SED -n 's/^[[:space:]]*boolean[[:space:]]*\([[:alpha:]]*\).*/\1/p')"
   if [ "$invert_status" = true ]; then
     invert=0 # Set the window to have normal color
   else
     invert=1 # Set the window to have inverted color
   fi
-  ${compton_dbus}win_set "${type_win}:${window}" string:invert_color_force "${type_enum}:${invert}" &
+  ${picom_dbus}win_set "${type_win}:${window}" string:invert_color_force "${type_enum}:${invert}" &
 else
-  echo "Cannot find $1 window."
-  exit 1;
+  stderr "Cannot find $1 window."
+  exit 1
 fi
-exit 0;
+exit 0


### PR DESCRIPTION
List of changes:

- Removed unnecessary if statement and unnecessary /dev/null redirect on line 19
- Line 26 can use argless printf rather than echo -n
- Error verbose prints in red and to STDERR rather than to STDOUT
  - (could change it back to print errors to STDOUT for compat)
- Textually replaced compton with picom where applicable
- Removed unnecessary semicolons after exit commands
- Replaced backticks with $()

I could've/likely missed a few things, however the script still seems runs the same for me.