### PR TITLE
Experimental backends: fade/hide blur-texture for transparent windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ doxygen/
 /src/backtrace-symbols.[ch]
 /compton*.trace
 *.orig
+/tests/log
+/tests/testcases/__pycache__/

--- a/src/event.c
+++ b/src/event.c
@@ -287,7 +287,7 @@ static inline void ev_map_notify(session_t *ps, xcb_map_notify_event_t *ev) {
 		return;
 	}
 
-	win_queue_update(w, WIN_UPDATE_MAP);
+	win_set_flags(w, WIN_FLAGS_MAPPED);
 
 	// FocusIn/Out may be ignored when the window is unmapped, so we must
 	// recheck focus here

--- a/src/event.c
+++ b/src/event.c
@@ -482,14 +482,7 @@ static inline void ev_property_notify(session_t *ps, xcb_property_notify_event_t
 			win_update_opacity_prop(ps, w);
 			// we cannot receive OPACITY change when window is destroyed
 			assert(w->state != WSTATE_DESTROYING);
-			w->opacity_target = win_calc_opacity_target(ps, w, false);
-			if (w->state == WSTATE_MAPPED) {
-				// See the winstate_t transition table
-				w->state = WSTATE_FADING;
-			}
-			if (!ps->redirected) {
-				CHECK(!win_skip_fading(ps, w));
-			}
+			win_update_opacity_target(ps, w);
 		}
 	}
 

--- a/src/win.c
+++ b/src/win.c
@@ -579,18 +579,17 @@ winmode_t win_calc_mode(const struct managed_win *w) {
  *
  * @param ps           current session
  * @param w            struct _win object representing the window
- * @param ignore_state whether window state should be ignored in opacity calculation
  *
  * @return target opacity
  */
-double win_calc_opacity_target(session_t *ps, const struct managed_win *w, bool ignore_state) {
+double win_calc_opacity_target(session_t *ps, const struct managed_win *w) {
 	double opacity = 1;
 
-	if (w->state == WSTATE_UNMAPPED && !ignore_state) {
+	if (w->state == WSTATE_UNMAPPED) {
 		// be consistent
 		return 0;
 	}
-	if ((w->state == WSTATE_UNMAPPING || w->state == WSTATE_DESTROYING) && !ignore_state) {
+	if (w->state == WSTATE_UNMAPPING || w->state == WSTATE_DESTROYING) {
 		return 0;
 	}
 	// Try obeying opacity property and window type opacity firstly
@@ -1929,7 +1928,7 @@ void unmap_win_start(session_t *ps, struct managed_win *w) {
 	w->a.map_state = XCB_MAP_STATE_UNMAPPED;
 	w->state = WSTATE_UNMAPPING;
 	w->opacity_target_old = fmax(w->opacity_target, w->opacity_target_old);
-	w->opacity_target = win_calc_opacity_target(ps, w, false);
+	w->opacity_target = win_calc_opacity_target(ps, w);
 
 	// Clear PIXMAP_STALE flag, since the window is unmapped there is no pixmap
 	// available so STALE doesn't make sense.
@@ -2114,7 +2113,7 @@ void map_win_start(session_t *ps, struct managed_win *w) {
 	// iff `state` is MAPPED
 	w->state = WSTATE_MAPPING;
 	w->opacity_target_old = 0;
-	w->opacity_target = win_calc_opacity_target(ps, w, false);
+	w->opacity_target = win_calc_opacity_target(ps, w);
 
 	log_debug("Window %#010x has opacity %f, opacity target is %f", w->base.id,
 	          w->opacity, w->opacity_target);
@@ -2154,7 +2153,7 @@ void map_win_start(session_t *ps, struct managed_win *w) {
  */
 void win_update_opacity_target(session_t *ps, struct managed_win *w) {
 	auto opacity_target_old = w->opacity_target;
-	w->opacity_target = win_calc_opacity_target(ps, w, false);
+	w->opacity_target = win_calc_opacity_target(ps, w);
 
 	if (opacity_target_old == w->opacity_target) {
 		return;

--- a/src/win.h
+++ b/src/win.h
@@ -310,12 +310,10 @@ bool win_get_class(session_t *ps, struct managed_win *w);
  *
  * @param ps           current session
  * @param w            struct _win object representing the window
- * @param ignore_state whether window state should be ignored in opacity calculation
  *
  * @return target opacity
  */
-double attr_pure win_calc_opacity_target(session_t *ps, const struct managed_win *w,
-                                         bool ignore_state);
+double attr_pure win_calc_opacity_target(session_t *ps, const struct managed_win *w);
 bool attr_pure win_should_dim(session_t *ps, const struct managed_win *w);
 void win_update_screen(session_t *, struct managed_win *);
 /**

--- a/src/win.h
+++ b/src/win.h
@@ -192,6 +192,8 @@ struct managed_win {
 	double opacity;
 	/// Target window opacity.
 	double opacity_target;
+	/// Previous window opacity.
+	double opacity_target_old;
 	/// true if window (or client window, for broken window managers
 	/// not transferring client window's _NET_WM_OPACITY value) has opacity prop
 	bool has_opacity_prop;
@@ -287,6 +289,7 @@ void win_set_focused(session_t *ps, struct managed_win *w);
 bool attr_pure win_should_fade(session_t *ps, const struct managed_win *w);
 void win_update_prop_shadow_raw(session_t *ps, struct managed_win *w);
 void win_update_prop_shadow(session_t *ps, struct managed_win *w);
+void win_update_opacity_target(session_t *ps, struct managed_win *w);
 void win_on_factor_change(session_t *ps, struct managed_win *w);
 /**
  * Update cache data in struct _win that depends on window size.

--- a/src/win.h
+++ b/src/win.h
@@ -131,7 +131,7 @@ struct managed_win {
 	/// See above about coordinate systems.
 	region_t bounding_shape;
 	/// Window flags. Definitions above.
-	int_fast16_t flags;
+	uint64_t flags;
 	/// The region of screen that will be obscured when windows above is painted,
 	/// in global coordinates.
 	/// We use this to reduce the pixels that needed to be paint when painting
@@ -252,12 +252,8 @@ struct managed_win {
 #endif
 };
 
-/// Process pending updates on a window. Has to be called in X critical section
-void win_process_updates(struct session *ps, struct managed_win *_w);
 /// Process pending images flags on a window. Has to be called in X critical section
 void win_process_flags(session_t *ps, struct managed_win *w);
-/// Queue an update on a window. A series of sanity checks are performed
-void win_queue_update(struct managed_win *_w, enum win_update update);
 /// Bind a shadow to the window, with color `c` and shadow kernel `kernel`
 bool win_bind_shadow(struct backend_base *b, struct managed_win *w, struct color c,
                      struct conv *kernel);
@@ -434,6 +430,14 @@ bool win_is_mapped_in_x(const struct managed_win *w);
 // Find the managed window immediately below `w` in the window stack
 struct managed_win *attr_pure win_stack_find_next_managed(const session_t *ps,
                                                           const struct list_node *w);
+/// Set flags on a window. Some sanity checks are performed
+void win_set_flags(struct managed_win *w, uint64_t flags);
+/// Clear flags on a window. Some sanity checks are performed
+void win_clear_flags(struct managed_win *w, uint64_t flags);
+/// Returns true if any of the flags in `flags` is set
+bool win_check_flags_any(struct managed_win *w, uint64_t flags);
+/// Returns true if all of the flags in `flags` are set
+bool win_check_flags_all(struct managed_win *w, uint64_t flags);
 
 /// Free all resources in a struct win
 void free_win_res(session_t *ps, struct managed_win *w);

--- a/src/win_defs.h
+++ b/src/win_defs.h
@@ -40,8 +40,8 @@ typedef enum {
 /// |  DESTROYING |    -    |    o     |   -   |  -    |   -    |  -     | Fading  |
 /// |             |         |          |       |       |        |        |finished |
 /// +-------------+---------+----------+-------+-------+--------+--------+---------+
-/// |   MAPPING   | Window  |  Window  |   o   |  -    |   -    | Fading |    -    |
-/// |             |unmapped |destroyed |       |       |        |finished|         |
+/// |   MAPPING   | Window  |  Window  |   o   |Opacity|   -    | Fading |    -    |
+/// |             |unmapped |destroyed |       |change |        |finished|         |
 /// +-------------+---------+----------+-------+-------+--------+--------+---------+
 /// |    FADING   | Window  |  Window  |   -   |  o    |   -    | Fading |    -    |
 /// |             |unmapped |destroyed |       |       |        |finished|         |

--- a/src/win_defs.h
+++ b/src/win_defs.h
@@ -27,11 +27,6 @@ typedef enum {
 	WMODE_SOLID,              // The window is opaque including the frame
 } winmode_t;
 
-/// Pending window updates
-enum win_update {
-	WIN_UPDATE_MAP = 1,
-};
-
 /// Transition table:
 /// (DESTROYED is when the win struct is destroyed and freed)
 /// ('o' means in all other cases)
@@ -86,9 +81,11 @@ enum win_flags {
 	WIN_FLAGS_SHADOW_STALE = 8,
 	/// shadow has not been generated
 	WIN_FLAGS_SHADOW_NONE = 16,
+	/// the window is mapped by X, we need to call map_win_start for it
+	WIN_FLAGS_MAPPED = 64,
 };
 
-static const int_fast16_t WIN_FLAGS_IMAGES_STALE =
+static const uint64_t WIN_FLAGS_IMAGES_STALE =
     WIN_FLAGS_PIXMAP_STALE | WIN_FLAGS_SHADOW_STALE;
 
 #define WIN_FLAGS_IMAGES_NONE (WIN_FLAGS_PIXMAP_NONE | WIN_FLAGS_SHADOW_NONE)

--- a/tests/configs/issue314.conf
+++ b/tests/configs/issue314.conf
@@ -1,5 +1,5 @@
 fading = true
-fade-in-step = 1
+fade-in-step = 0.01
 fade-out-step = 0.01
 inactive-opacity = 0
 blur-background = true

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -10,3 +10,5 @@ cd $(dirname $0)
 ./run_one_test.sh $exe configs/issue239_3.conf testcases/issue239_3.py
 ./run_one_test.sh $exe configs/issue239_3.conf testcases/issue239_3_norefresh.py
 ./run_one_test.sh $exe configs/issue314.conf testcases/issue314.py
+./run_one_test.sh $exe configs/issue314.conf testcases/issue314_2.py
+./run_one_test.sh $exe configs/issue314.conf testcases/issue314_3.py

--- a/tests/testcases/issue314_2.py
+++ b/tests/testcases/issue314_2.py
@@ -12,33 +12,35 @@ visual = setup.roots[0].root_visual
 depth = setup.roots[0].root_depth
 x = xproto.xprotoExtension(conn)
 
+opacity_80 = [int(0xffffffff * 0.8), ]
+opacity_single = [int(0xffffffff * 0.002), ]
+
 # issue 314 is caused by changing a windows target opacity during its fade-in/-out transition
 wid1 = conn.generate_id()
 print("Window 1: ", hex(wid1))
-wid2 = conn.generate_id()
-print("Window 2: ", hex(wid2))
+
+atom = "_NET_WM_WINDOW_OPACITY"
+opacity_atom = conn.core.InternAtom(False, len(atom), atom).reply().atom
 
 # Create windows
 conn.core.CreateWindowChecked(depth, wid1, root, 0, 0, 100, 100, 0, xproto.WindowClass.InputOutput, visual, 0, []).check()
-conn.core.CreateWindowChecked(depth, wid2, root, 0, 0, 100, 100, 0, xproto.WindowClass.InputOutput, visual, 0, []).check()
 
 # Set Window names
 set_window_name(conn, wid1, "Test window 1")
-set_window_name(conn, wid2, "Test window 2")
 
-# Check updating opacity while UNMAPPING/DESTROYING windows
-print("Mapping 1")
+# Check updating opacity while MAPPING windows
+print("Mapping window")
 conn.core.MapWindowChecked(wid1).check()
-print("Mapping 2")
-conn.core.MapWindowChecked(wid2).check()
 time.sleep(0.5)
 
-x.SetInputFocusChecked(0, wid1, xproto.Time.CurrentTime).check()
+print("Update opacity while fading in")
+conn.core.ChangePropertyChecked(xproto.PropMode.Replace, wid1, opacity_atom, xproto.Atom.CARDINAL, 32, 1, opacity_80).check()
+time.sleep(0.2)
+conn.core.ChangePropertyChecked(xproto.PropMode.Replace, wid1, opacity_atom, xproto.Atom.CARDINAL, 32, 1, opacity_single).check()
+time.sleep(1)
+
+conn.core.DeletePropertyChecked(wid1, opacity_atom).check()
 time.sleep(0.5)
 
 # Destroy the windows
-print("Destroy 1 while fading out")
 conn.core.DestroyWindowChecked(wid1).check()
-x.SetInputFocusChecked(0, wid2, xproto.Time.CurrentTime).check()
-time.sleep(1)
-conn.core.DestroyWindowChecked(wid2).check()

--- a/tests/testcases/issue314_3.py
+++ b/tests/testcases/issue314_3.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+
+import xcffib.xproto as xproto
+import xcffib
+import time
+from common import set_window_name, trigger_root_configure
+
+conn = xcffib.connect()
+setup = conn.get_setup()
+root = setup.roots[0].root
+visual = setup.roots[0].root_visual
+depth = setup.roots[0].root_depth
+x = xproto.xprotoExtension(conn)
+
+opacity_100 = [0xffffffff, ]
+opacity_80 = [int(0xffffffff * 0.8), ]
+opacity_single = [int(0xffffffff * 0.002), ]
+opacity_0 = [0, ]
+
+# issue 314 is caused by changing a windows target opacity during its fade-in/-out transition
+wid1 = conn.generate_id()
+print("Window 1: ", hex(wid1))
+
+atom = "_NET_WM_WINDOW_OPACITY"
+opacity_atom = conn.core.InternAtom(False, len(atom), atom).reply().atom
+
+# Create windows
+conn.core.CreateWindowChecked(depth, wid1, root, 0, 0, 100, 100, 0, xproto.WindowClass.InputOutput, visual, 0, []).check()
+
+# Set Window names
+set_window_name(conn, wid1, "Test window 1")
+
+# Check updating opacity while FADING windows
+print("Mapping window")
+conn.core.MapWindowChecked(wid1).check()
+time.sleep(1.2)
+
+print("Update opacity while fading out")
+conn.core.ChangePropertyChecked(xproto.PropMode.Replace, wid1, opacity_atom, xproto.Atom.CARDINAL, 32, 1, opacity_single).check()
+time.sleep(0.2)
+conn.core.ChangePropertyChecked(xproto.PropMode.Replace, wid1, opacity_atom, xproto.Atom.CARDINAL, 32, 1, opacity_0).check()
+time.sleep(1)
+
+print("Change from fading in to fading out")
+conn.core.ChangePropertyChecked(xproto.PropMode.Replace, wid1, opacity_atom, xproto.Atom.CARDINAL, 32, 1, opacity_80).check()
+time.sleep(0.5)
+conn.core.ChangePropertyChecked(xproto.PropMode.Replace, wid1, opacity_atom, xproto.Atom.CARDINAL, 32, 1, opacity_0).check()
+time.sleep(1)
+
+print("Update opacity while fading in")
+conn.core.ChangePropertyChecked(xproto.PropMode.Replace, wid1, opacity_atom, xproto.Atom.CARDINAL, 32, 1, opacity_80).check()
+time.sleep(0.2)
+conn.core.ChangePropertyChecked(xproto.PropMode.Replace, wid1, opacity_atom, xproto.Atom.CARDINAL, 32, 1, opacity_100).check()
+time.sleep(1)
+
+print("Change from fading out to fading in")
+conn.core.ChangePropertyChecked(xproto.PropMode.Replace, wid1, opacity_atom, xproto.Atom.CARDINAL, 32, 1, opacity_0).check()
+time.sleep(0.5)
+conn.core.ChangePropertyChecked(xproto.PropMode.Replace, wid1, opacity_atom, xproto.Atom.CARDINAL, 32, 1, opacity_80).check()
+time.sleep(1)
+
+# Destroy the windows
+conn.core.DestroyWindowChecked(wid1).check()


### PR DESCRIPTION
The new experimental backends did not honor the `--blur-background-fixed` option. This implements handling of said option in the new backends.

If set to `false`, the (premultiplied) opacity of the blur-texture is dependent on the window opacity preventing awkward-looking blurred rectangles behind transparent windows especially with low `--inactive-opacity` values.

Example: https://imgur.com/a/sCDVqAI
In-depth discussion in https://github.com/tryone144/compton/issues/2

Stuff for further discussion:
The current (longtime) default of `false` did irritate some users who used a strong blur with `active-opacity` and `opacity-rule`: https://github.com/tryone144/compton/issues/25, https://github.com/tryone144/compton/issues/33