### PR TITLE
dual-kawase blur algorithm for new OpenGL backend

### DIFF
--- a/man/picom.1.asciidoc
+++ b/man/picom.1.asciidoc
@@ -166,7 +166,7 @@ OPTIONS
 *--detect-client-leader*::
 	Use 'WM_CLIENT_LEADER' to group windows, and consider windows in the same group focused at the same time. 'WM_TRANSIENT_FOR' has higher priority if *--detect-transient* is enabled, too.
 
-*--blur-method*, *--blur-size*, *--blur-deviation*::
+*--blur-method*, *--blur-size*, *--blur-deviation*, *--blur-strength*::
 	Parameters for background blurring, see the *BLUR* section for more information.
 
 *--blur-background*::
@@ -397,8 +397,8 @@ Available options of the 'blur' section are: ::
 
   *method*:::
     A string. Controls the blur method. Corresponds to the *--blur-method* command line option. Available choices are:
-      'none' to disable blurring; 'gaussian' for gaussian blur; 'box' for box blur; 'kernel' for convolution blur with a custom kernel.
-    Note: 'gaussian' and 'box' blur methods are only supported by the experimental backends.
+      'none' to disable blurring; 'gaussian' for gaussian blur; 'box' for box blur; 'kernel' for convolution blur with a custom kernel; 'dual_kawase' for dual-filter kawase blur.
+    Note: 'gaussian', 'box' and 'dual_kawase' blur methods are only supported by the experimental backends.
     (default: none)
 
   *size*:::
@@ -406,6 +406,9 @@ Available options of the 'blur' section are: ::
 
   *deviation*:::
     A floating point number. The standard deviation for the 'gaussian' blur method. Corresponds to the *--blur-deviation* command line option (default: 0.84089642).
+
+  *strength*:::
+    An integer in the range 0-20. The strength of the 'dual_kawase' blur method. Corresponds to the *--blur-strength* command line option. If set to zero, the value requested by *--blur-size* is approximated (default: 5).
 
   *kernel*:::
     A string. The kernel to use for the 'kernel' blur method, specified in the same format as the *--blur-kerns* option. Corresponds to the *--blur-kerns* command line option.

--- a/picom.sample.conf
+++ b/picom.sample.conf
@@ -143,6 +143,8 @@ focus-exclude = [ "class_g = 'Cairo-clock'" ];
 # blur-size = 12
 #
 # blur-deviation = false
+#
+# blur-strength = 5
 
 # Blur background of semi-transparent / ARGB windows. 
 # Bad in performance, with driver-dependent behavior. 

--- a/src/backend/backend.h
+++ b/src/backend/backend.h
@@ -5,8 +5,8 @@
 
 #include <stdbool.h>
 
-#include "config.h"
 #include "compiler.h"
+#include "config.h"
 #include "driver.h"
 #include "kernel.h"
 #include "region.h"
@@ -63,6 +63,11 @@ struct box_blur_args {
 struct kernel_blur_args {
 	struct conv **kernels;
 	int kernel_count;
+};
+
+struct dual_kawase_blur_args {
+	int size;
+	int strength;
 };
 
 struct backend_operations {

--- a/src/backend/backend_common.h
+++ b/src/backend/backend_common.h
@@ -16,6 +16,15 @@ typedef struct conv conv;
 typedef struct backend_base backend_t;
 struct backend_operations;
 
+struct dual_kawase_params {
+	/// Number of downsample passes
+	int iterations;
+	/// Pixel offset for down- and upsample
+	float offset;
+	/// Save area around blur target (@ref resize_width, @ref resize_height)
+	int expand;
+};
+
 bool build_shadow(xcb_connection_t *, xcb_drawable_t, double opacity, int width,
                   int height, const conv *kernel, xcb_render_picture_t shadow_pixel,
                   xcb_pixmap_t *pixmap, xcb_render_picture_t *pict);
@@ -41,3 +50,4 @@ default_backend_render_shadow(backend_t *backend_data, int width, int height,
 void init_backend_base(struct backend_base *base, session_t *ps);
 
 struct conv **generate_blur_kernel(enum blur_method method, void *args, int *kernel_count);
+struct dual_kawase_params *generate_dual_kawase_params(void *args);

--- a/src/backend/gl/gl_common.c
+++ b/src/backend/gl/gl_common.c
@@ -977,6 +977,12 @@ void *gl_create_blur_context(backend_t *base, enum blur_method method, void *arg
 		return ctx;
 	}
 
+	if (method == BLUR_METHOD_DUAL_KAWASE) {
+		log_warn("Blur method 'dual_kawase' is not yet implemented.");
+		ctx->method = BLUR_METHOD_NONE;
+		return ctx;
+	}
+
 	int nkernels;
 	ctx->method = BLUR_METHOD_KERNEL;
 	if (method == BLUR_METHOD_KERNEL) {

--- a/src/backend/gl/gl_common.h
+++ b/src/backend/gl/gl_common.h
@@ -36,6 +36,7 @@ typedef struct {
 	GLint unifm_opacity;
 	GLint orig_loc;
 	GLint texorig_loc;
+	GLint scale_loc;
 } gl_blur_shader_t;
 
 typedef struct {

--- a/src/backend/xrender/xrender.c
+++ b/src/backend/xrender/xrender.c
@@ -507,6 +507,12 @@ void *create_blur_context(backend_t *base attr_unused, enum blur_method method, 
 		ret->method = BLUR_METHOD_NONE;
 		return ret;
 	}
+	if (method == BLUR_METHOD_DUAL_KAWASE) {
+		log_warn("Blur method 'dual_kawase' is not compatible with the 'xrender' "
+		         "backend.");
+		ret->method = BLUR_METHOD_NONE;
+		return ret;
+	}
 
 	ret->method = BLUR_METHOD_KERNEL;
 	struct conv **kernels;

--- a/src/config.c
+++ b/src/config.c
@@ -88,6 +88,13 @@ enum blur_method parse_blur_method(const char *src) {
 		return BLUR_METHOD_BOX;
 	} else if (strcmp(src, "gaussian") == 0) {
 		return BLUR_METHOD_GAUSSIAN;
+	} else if (strcmp(src, "dual_kawase") == 0) {
+		return BLUR_METHOD_DUAL_KAWASE;
+	} else if (strcmp(src, "kawase") == 0) {
+		log_warn("Blur method 'kawase' has been renamed to 'dual_kawase'. "
+		         "Interpreted as 'dual_kawase', but this will stop working "
+		         "soon.");
+		return BLUR_METHOD_DUAL_KAWASE;
 	} else if (strcmp(src, "none") == 0) {
 		return BLUR_METHOD_NONE;
 	}
@@ -542,6 +549,7 @@ char *parse_config(options_t *opt, const char *config_file, bool *shadow_enable,
 	    .blur_method = BLUR_METHOD_NONE,
 	    .blur_radius = 3,
 	    .blur_deviation = 0.84089642,
+	    .blur_strength = 5,
 	    .blur_background_frame = false,
 	    .blur_background_fixed = false,
 	    .blur_background_blacklist = NULL,

--- a/src/config.h
+++ b/src/config.h
@@ -23,8 +23,8 @@
 #include "kernel.h"
 #include "log.h"
 #include "region.h"
-#include "win_defs.h"
 #include "types.h"
+#include "win_defs.h"
 
 typedef struct session session_t;
 
@@ -60,6 +60,7 @@ enum blur_method {
 	BLUR_METHOD_KERNEL,
 	BLUR_METHOD_BOX,
 	BLUR_METHOD_GAUSSIAN,
+	BLUR_METHOD_DUAL_KAWASE,
 	BLUR_METHOD_INVALID,
 };
 
@@ -189,6 +190,8 @@ typedef struct options {
 	int blur_radius;
 	// Standard deviation for the gaussian blur
 	double blur_deviation;
+	// Strength of the dual_kawase blur
+	int blur_strength;
 	/// Whether to blur background when the window frame is not opaque.
 	/// Implies blur_background.
 	bool blur_background_frame;

--- a/src/config_libconfig.c
+++ b/src/config_libconfig.c
@@ -530,6 +530,8 @@ char *parse_config_libconfig(options_t *opt, const char *config_file, bool *shad
 	config_lookup_int(&cfg, "blur-size", &opt->blur_radius);
 	// --blur-deviation
 	config_lookup_float(&cfg, "blur-deviation", &opt->blur_deviation);
+	// --blur-strength
+	config_lookup_int(&cfg, "blur-strength", &opt->blur_strength);
 	// --blur-background
 	if (config_lookup_bool(&cfg, "blur-background", &ival) && ival) {
 		if (opt->blur_method == BLUR_METHOD_NONE) {
@@ -640,6 +642,7 @@ char *parse_config_libconfig(options_t *opt, const char *config_file, bool *shad
 		}
 
 		config_setting_lookup_float(blur_cfg, "deviation", &opt->blur_deviation);
+		config_setting_lookup_int(blur_cfg, "strength", &opt->blur_strength);
 	}
 
 	// Wintype settings

--- a/src/picom.c
+++ b/src/picom.c
@@ -431,6 +431,7 @@ static bool initialize_blur(session_t *ps) {
 	struct kernel_blur_args kargs;
 	struct gaussian_blur_args gargs;
 	struct box_blur_args bargs;
+	struct dual_kawase_blur_args dkargs;
 
 	void *args = NULL;
 	switch (ps->o.blur_method) {
@@ -447,6 +448,11 @@ static bool initialize_blur(session_t *ps) {
 		gargs.size = ps->o.blur_radius;
 		gargs.deviation = ps->o.blur_deviation;
 		args = (void *)&gargs;
+		break;
+	case BLUR_METHOD_DUAL_KAWASE:
+		dkargs.size = ps->o.blur_radius;
+		dkargs.strength = ps->o.blur_strength;
+		args = (void *)&dkargs;
 		break;
 	default: return true;
 	}


### PR DESCRIPTION
<!-- Please enable "Allow edits from maintainers" so we can make necessary changes to your PR -->

This PR implements the dual-filter kawase blur algorithm as [found in KWin](https://kwin.kde.narkive.com/aSqRYYw7/d9848-updated-the-blur-method-to-use-the-more-efficient-dual-kawase-blur-algorithm).

![demo](https://i.imgur.com/VY32UHC.png)

Usable with `--blur-method dual_kawase --blur-strength 7`.

**~~This is currently work-in-progress and open for comments. DO NOT MERGE.~~**
Should be ready to merge now.

Previous discussion: https://github.com/yshui/picom/issues/32
See also: https://github.com/yshui/picom/pull/361

EDIT: Sorry, clicked submit too fast...