### PR TITLE
gl_common: set `glViewport()` to maximum supported size

### DIFF
--- a/src/backend/gl/gl_common.h
+++ b/src/backend/gl/gl_common.h
@@ -68,8 +68,10 @@ struct gl_data {
 	backend_t base;
 	// If we are using proprietary NVIDIA driver
 	bool is_nvidia;
-	// Height and width of the viewport
+	// Height and width of the root window
 	int height, width;
+	// Height and width of the gl viewport
+	int vp_height, vp_width;
 	gl_win_shader_t win_shader;
 	gl_brightness_shader_t brightness_shader;
 	gl_fill_shader_t fill_shader;


### PR DESCRIPTION
Similar to the changes in #349 and as discussed over there, this PR sets the viewport to the maximum supported dimensions in the new OpenGL backend. In contrast to #349, the projection matrix in each shader has to be set only once when setting up the shader program and not for each draw call.

#### Changes
- Query maximum supported dimensions of `glViewport()` when initializing
so we don't have to worry about differently sized textures when
rendering (usually the same as the maximum supported texture size, but
dependend on the driver).
- Set projection matrix in all shaders at startup to queried viewport
dimensions. Allows using screen coordinates for all vertex positions
without having to keep track of framebuffer dimensions.
- Follow recommendations and set `glViewport()` to queried maximum dimensions
for each draw call (`glDraw*()`, `glClear()`).

#### Rationale
Instead of keeping track of all framebuffer/texture sizes and updating the viewport and projection matrix for each shader and draw call, we set them up once to "cancel each other out" regardless of the actual buffer dimensions.
`glViewport()` itself is only responsible for the transformation from NDC to screen space, so setting it to larger-than-screen dimensions has no effect on video memory. Since the maximum dimensions are usually the same as the maximum supported texture sizes and not that much bigger than actual screen sizes ([OpenGL Hardware Database](https://opengl.gpuinfo.org/displaycapability.php?name=GL_MAX_VIEWPORT_DIMS%5B0%5D)) there is no loss in precision to be expected. Initial testing showed that window coordinates are clipped to screen dimensions regardless, so that we aren't even trying to render outside the screen bounds.

#### Related to #382 
Having a unified viewport simplifies rendering passes for the dual-filter kawase blur algorithm.