### PR TITLE
meson: Respect mandir.

### DIFF
--- a/man/meson.build
+++ b/man/meson.build
@@ -7,6 +7,7 @@ if get_option('with_docs')
 		                        'picom-version='+version,
 		                        '--format', 'manpage', '@INPUT@', '-D',
 		                        meson.current_build_dir()],
-		              install: true, install_dir: 'share/man/man1/')
+		              install: true,
+		              install_dir: join_paths(get_option('mandir'), 'man1'))
 	endforeach
 endif


### PR DESCRIPTION
Respects the default `mandir` meson option. There will be no change in behavior unless `mandir` is set. Not all distros use `share/man`.
