### PR TITLE
meson: Allow building without compton compat.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -70,11 +70,14 @@ subdir('src')
 subdir('man')
 
 install_data('bin/picom-trans', install_dir: get_option('bindir'))
-install_data('compton.desktop', install_dir: 'share/applications')
 install_data('picom.desktop', install_dir: 'share/applications')
-install_data('media/icons/48x48/compton.png',
-             install_dir: 'share/icons/hicolor/48x48/apps')
-install_data('media/compton.svg',
-             install_dir: 'share/icons/hicolor/scalable/apps')
 
-meson.add_install_script('meson/install.sh')
+if get_option('compton')
+	install_data('compton.desktop', install_dir: 'share/applications')
+	install_data('media/icons/48x48/compton.png',
+                     install_dir: 'share/icons/hicolor/48x48/apps')
+	install_data('media/compton.svg',
+                     install_dir: 'share/icons/hicolor/scalable/apps')
+
+	meson.add_install_script('meson/install.sh')
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -9,6 +9,8 @@ option('dbus', type: 'boolean', value: true, description: 'Enable support for D-
 
 option('xrescheck', type: 'boolean', value: false, description: 'Enable X resource leak checker (for debug only)')
 
+option('compton', type: 'boolean', value: true, description: 'Install backwards compat with compton')
+
 option('with_docs', type: 'boolean', value: false, description: 'Build documentation and man pages')
 
 option('modularize', type: 'boolean', value: false, description: 'Build with clang\'s module system')


### PR DESCRIPTION
This allows disabling installing several files that conflict with compton. By default they will still be installed unless `compton` is set to `true`.

This helps in case the system has both compton and picom installed.