### PR TITLE
Better blur texture sampling (in experimental backends)

### DIFF
--- a/src/backend/gl/gl_common.h
+++ b/src/backend/gl/gl_common.h
@@ -32,6 +32,7 @@ typedef struct {
 // Program and uniforms for blur shader
 typedef struct {
 	GLuint prog;
+	GLint unifm_pixel_norm;
 	GLint unifm_opacity;
 	GLint orig_loc;
 	GLint texorig_loc;
@@ -168,7 +169,8 @@ static inline void gl_check_err_(const char *func, int line) {
 }
 
 static inline void gl_clear_err(void) {
-	while (glGetError() != GL_NO_ERROR);
+	while (glGetError() != GL_NO_ERROR)
+		;
 }
 
 #define gl_check_err() gl_check_err_(__func__, __LINE__)


### PR DESCRIPTION
<!-- Please enable "Allow edits from maintainers" so we can make necessary changes to your PR -->
### Overview
Use correct wrap/repeat setting for blur textures to prevent darkening around the screen borders. This occurs due to sampling outside of the texture, especially noticeable with larger blur radii.
The required changes to the fragment shader allowed for further improvements by utilizing the linear interpolation hardware in a GPU in the glx backend.
<details>
<summary>Old behavior:</summary>
<img alt="blur_wrap_old" src="https://user-images.githubusercontent.com/9111821/84069657-2906fb00-a9cb-11ea-8822-7c7a3989c917.jpg">
</details>
<details>
<summary>New behavior:</summary>
<img alt="blur_wrap_new" src="https://user-images.githubusercontent.com/9111821/84069648-24dadd80-a9cb-11ea-9b12-3018973ca7d2.jpg">
</details>

### Changes
1. Use correct `REPEAT` mode `PAD` when creating blur pictures in the xrender backend to pad the 
 image with edge pixels.
2. Use correct `WRAP` mode `CLAMP_TO_EDGE` when creating blur textures in the glx backend to clamp sampling to the edge pixels. Required changes to the fragment shader:
    - Use `texture2D()` instead of `texelFetch()`, as the latter does not respect `WRAP` settings.
    - Supply size of a pixel in normalized texture coordinates as new uniform to keep using pixel coordinates and offsets.
3. Since we are now using `texture2D()` we can use the hardware accelerated linear interpolation on texture sampling to effectively sample two pixels with one `texture2D()` call. By precomputing the required offsets when creating the blur-shader we can reduce the number of texture accesses by half. This technique has been described in detail in [this](http://rastergrid.com/blog/2010/09/efficient-gaussian-blur-with-linear-sampling/) blog article.

This PR only fixes it for the new experimental backends. The legacy xrender backend has the same darkening problem while the glx backend seems to sample random junk. If wanted these may be fixed in a second PR.