### PR TITLE
Fix crashes when trying to (re-)create shadows for destroyed windows

### DIFF
--- a/src/win.c
+++ b/src/win.c
@@ -2039,6 +2039,20 @@ bool destroy_win_start(session_t *ps, struct win *w) {
 		// Do this before changing the window state to destroying
 		win_clear_flags(mw, WIN_FLAGS_IMAGES_STALE);
 
+		// If size/shape/position information is stale, win_process_update_flags
+		// will update them and add the new window extents to damage. Since the
+		// window has been destroyed, we cannot get the complete information at
+		// this point, so we just add what we currently have to the damage.
+		if (win_check_flags_any(mw, WIN_FLAGS_SIZE_STALE | WIN_FLAGS_POSITION_STALE)) {
+			add_damage_from_win(ps, mw);
+		}
+
+		// Clear some flags about stale window information. Because now the window
+		// is destroyed, we can't update them anyway.
+		win_clear_flags(mw, WIN_FLAGS_SIZE_STALE | WIN_FLAGS_POSITION_STALE |
+		                        WIN_FLAGS_PROPERTY_STALE |
+		                        WIN_FLAGS_FACTOR_CHANGED | WIN_FLAGS_CLIENT_STALE);
+
 		// Update state flags of a managed window
 		mw->state = WSTATE_DESTROYING;
 		mw->a.map_state = XCB_MAP_STATE_UNMAPPED;

--- a/src/win.c
+++ b/src/win.c
@@ -2030,10 +2030,14 @@ bool destroy_win_start(session_t *ps, struct win *w) {
 	}
 
 	if (w->managed) {
-		// Clear PIXMAP_STALE flag, since the window is destroyed there is no
-		// pixmap available so STALE doesn't make sense.
+		// Clear IMAGES_STALE flags since the window is destroyed: Clear
+		// PIXMAP_STALE as there is no pixmap available anymore, so STALE doesn't
+		// make sense.
+		// XXX Clear SHADOW_STALE as setting/clearing flags on a destroyed window
+		// doesn't work leading to an inconsistent state where the shadow is
+		// refreshed but the flags are stuck in STALE.
 		// Do this before changing the window state to destroying
-		win_clear_flags(mw, WIN_FLAGS_PIXMAP_STALE);
+		win_clear_flags(mw, WIN_FLAGS_IMAGES_STALE);
 
 		// Update state flags of a managed window
 		mw->state = WSTATE_DESTROYING;

--- a/tests/configs/issue394.conf
+++ b/tests/configs/issue394.conf
@@ -1,0 +1,4 @@
+fading = true;
+fade-in-step = 1;
+fade-out-step = 0.01;
+shadow = true;

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -16,3 +16,4 @@ eval `dbus-launch --sh-syntax`
 ./run_one_test.sh $exe configs/issue314.conf testcases/issue314_3.py
 ./run_one_test.sh $exe /dev/null testcases/issue299.py
 ./run_one_test.sh $exe configs/issue465.conf testcases/issue465.py
+./run_one_test.sh $exe configs/issue394.conf testcases/issue394.py

--- a/tests/testcases/common.py
+++ b/tests/testcases/common.py
@@ -28,6 +28,11 @@ def set_window_class(conn, wid, name):
     str_type = to_atom(conn, "STRING")
     conn.core.ChangePropertyChecked(xproto.PropMode.Replace, wid, prop_name, str_type, 8, len(name), name).check()
 
+def set_window_size(conn, wid, width, height):
+    value_mask = xproto.ConfigWindow.Width | xproto.ConfigWindow.Height
+    value_list = [width, height]
+    conn.core.ConfigureWindowChecked(wid, value_mask, value_list).check()
+
 def find_picom_window(conn):
     prop_name = to_atom(conn, "WM_NAME")
     setup = conn.get_setup()

--- a/tests/testcases/issue394.py
+++ b/tests/testcases/issue394.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+
+import xcffib.xproto as xproto
+import xcffib
+import time
+from common import set_window_name, set_window_size
+
+conn = xcffib.connect()
+setup = conn.get_setup()
+root = setup.roots[0].root
+visual = setup.roots[0].root_visual
+depth = setup.roots[0].root_depth
+
+# issue 394 is caused by a window getting a size update just before destroying leading to a shadow update on destroyed window.
+wid = conn.generate_id()
+print("Window id is ", hex(wid))
+
+# Create a window
+conn.core.CreateWindowChecked(depth, wid, root, 0, 0, 100, 100, 0, xproto.WindowClass.InputOutput, visual, 0, []).check()
+
+# Set Window name so it doesn't get a shadow
+set_window_name(conn, wid, "Test Window")
+
+# Map the window
+print("mapping")
+conn.core.MapWindowChecked(wid).check()
+
+time.sleep(0.5)
+
+# Resize the window and destroy
+print("resize and destroy")
+set_window_size(conn, wid, 150, 150)
+conn.core.DestroyWindowChecked(wid).check()
+
+time.sleep(0.5)


### PR DESCRIPTION
This should fix various crashes where the shadow images created/updated in-time (both legacy and experimental backends).

<details>
<summary>EDIT: Fix has already been merged outside of this PR</summary>

First of all, fixes https://github.com/yshui/picom/issues/465 by partially reverting https://github.com/yshui/picom/commit/32754b0 (this seems to be the "benefit to keep them separate").
Shadow images might be updated/invalidated (via the `SHADOW_STALE` flag) depending on the focus-state (in `recheck_focus()`). We therefore have to refresh/create shadow images after that. Handling of the `MAPPED` flag however still has to be done before focus checking, otherwise we introduce a single frame lag for windows that are to be mapped and have rules depending on the focus-state.
@yshui I hope the naming for the split flag_update function is okay.

</details>

Furthermore, by expanding https://github.com/yshui/picom/commit/f493447b33daf009cc0a15fa52f52115bbc91cc9 to clear the `SHADOW_STALE` flag as well we prevent recreation of shadow textures for windows that just got unmapped/destroyed.
~~@yshui Not sure if this is the right approach but this seems to do the trick (the comment suggest this is the reason `PIXMAP_STALE` is cleared as well).~~ Not quite the right way. Something like this seems to be part of the reason for #239.

At least https://github.com/yshui/picom/issues/394 seems to be caused by windows that get destroyed but for some reason their shadow images get invalidated and are to be recreated (~~which fails for a non-existent window~~). This sets the `SHADOW_NONE` directly but won't update the `SHADOW_NONE` and `SHADOW_STALE` flags since the window is already destroyed. I haven't dug deep enough yet but the windows causing it seem to trigger an event after they are unmapped/destroyed. Fade-out seems to exaggerate this problem. The offending windows then have both `SHADOW_NONE` and `SHADOW_STALE` flags set.

I'm going to ping possible related issues to confirm this fixed their crashes as well: https://github.com/yshui/picom/issues/390, https://github.com/yshui/picom/issues/393, https://github.com/yshui/picom/issues/396, https://github.com/yshui/picom/issues/425.