### PR TITLE
Do not use single quotes in the example config

### DIFF
--- a/picom.sample.conf
+++ b/picom.sample.conf
@@ -3,8 +3,8 @@
 #################################
 
 
-# Enabled client-side shadows on windows. Note desktop windows 
-# (windows with '_NET_WM_WINDOW_TYPE_DESKTOP') never get shadow, 
+# Enabled client-side shadows on windows. Note desktop windows
+# (windows with '_NET_WM_WINDOW_TYPE_DESKTOP') never get shadow,
 # unless explicitly requested using the wintypes option.
 #
 # shadow = false
@@ -52,11 +52,11 @@ shadow-exclude = [
 ];
 
 # Specify a X geometry that describes the region in which shadow should not
-# be painted in, such as a dock window region. Use 
+# be painted in, such as a dock window region. Use
 #    shadow-exclude-reg = "x10+0+0"
 # for example, if the 10 pixels on the bottom of the screen should not have shadows painted on.
 #
-# shadow-exclude-reg = "" 
+# shadow-exclude-reg = ""
 
 # Crop shadow of a window fully on a particular Xinerama screen to the screen.
 # xinerama-shadow-crop = false
@@ -70,7 +70,7 @@ shadow-exclude = [
 # Fade windows in/out when opening/closing and when opacity changes,
 #  unless no-fading-openclose is used.
 # fading = false
-fading = true
+fading = true;
 
 # Opacity change between steps while fading in. (0.01 - 1.0, defaults to 0.028)
 # fade-in-step = 0.028
@@ -123,9 +123,9 @@ focus-exclude = [ "class_g = 'Cairo-clock'" ];
 # Use fixed inactive dim value, instead of adjusting according to window opacity.
 # inactive-dim-fixed = 1.0
 
-# Specify a list of opacity rules, in the format `PERCENT:PATTERN`, 
-# like `50:name *= "Firefox"`. picom-trans is recommended over this. 
-# Note we don't make any guarantee about possible conflicts with other 
+# Specify a list of opacity rules, in the format `PERCENT:PATTERN`,
+# like `50:name *= "Firefox"`. picom-trans is recommended over this.
+# Note we don't make any guarantee about possible conflicts with other
 # programs that set '_NET_WM_WINDOW_OPACITY' on frame or client windows.
 # example:
 #    opacity-rule = [ "80:class_g = 'URxvt'" ];
@@ -139,22 +139,22 @@ focus-exclude = [ "class_g = 'Cairo-clock'" ];
 
 
 # Parameters for background blurring, see the *BLUR* section for more information.
-# blur-method = 
+# blur-method =
 # blur-size = 12
 #
 # blur-deviation = false
 #
 # blur-strength = 5
 
-# Blur background of semi-transparent / ARGB windows. 
-# Bad in performance, with driver-dependent behavior. 
+# Blur background of semi-transparent / ARGB windows.
+# Bad in performance, with driver-dependent behavior.
 # The name of the switch may change without prior notifications.
 #
 # blur-background = false
 
-# Blur background of windows when the window frame is not opaque. 
+# Blur background of windows when the window frame is not opaque.
 # Implies:
-#    blur-background 
+#    blur-background
 # Bad in performance, with driver-dependent behavior. The name may change.
 #
 # blur-background-frame = false
@@ -168,7 +168,7 @@ focus-exclude = [ "class_g = 'Cairo-clock'" ];
 # example:
 #   blur-kern = "5,5,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1";
 #
-# blur-kern = ''
+# blur-kern = ""
 blur-kern = "3x3box";
 
 
@@ -190,17 +190,17 @@ blur-background-exclude = [
 # Specify the backend to use: `xrender`, `glx`, or `xr_glx_hybrid`.
 # `xrender` is the default one.
 #
-# backend = 'glx'
+# backend = "glx"
 backend = "xrender";
 
 # Enable/disable VSync.
 # vsync = false
-vsync = true
+vsync = true;
 
 # Enable remote control via D-Bus. See the *D-BUS API* section below for more details.
 # dbus = false
 
-# Try to detect WM windows (a non-override-redirect window with no 
+# Try to detect WM windows (a non-override-redirect window with no
 # child that has 'WM_STATE') and mark them as active.
 #
 # mark-wmwin-focused = false
@@ -210,7 +210,7 @@ mark-wmwin-focused = true;
 # mark-ovredir-focused = false
 mark-ovredir-focused = true;
 
-# Try to detect windows with rounded corners and don't consider them 
+# Try to detect windows with rounded corners and don't consider them
 # shaped windows. The accuracy is not very high, unfortunately.
 #
 # detect-rounded-corners = false
@@ -222,20 +222,20 @@ detect-rounded-corners = true;
 # detect-client-opacity = false
 detect-client-opacity = true;
 
-# Specify refresh rate of the screen. If not specified or 0, picom will 
+# Specify refresh rate of the screen. If not specified or 0, picom will
 # try detecting this with X RandR extension.
 #
 # refresh-rate = 60
-refresh-rate = 0
+refresh-rate = 0;
 
-# Use EWMH '_NET_ACTIVE_WINDOW' to determine currently focused window, 
-# rather than listening to 'FocusIn'/'FocusOut' event. Might have more accuracy, 
+# Use EWMH '_NET_ACTIVE_WINDOW' to determine currently focused window,
+# rather than listening to 'FocusIn'/'FocusOut' event. Might have more accuracy,
 # provided that the WM supports it.
 #
 # use-ewmh-active-win = false
 
-# Unredirect all windows if a full-screen opaque window is detected, 
-# to maximize performance for full-screen windows. Known to cause flickering 
+# Unredirect all windows if a full-screen opaque window is detected,
+# to maximize performance for full-screen windows. Known to cause flickering
 # when redirecting/unredirecting windows.
 #
 # unredir-if-possible = false
@@ -246,84 +246,84 @@ refresh-rate = 0
 # Conditions of windows that shouldn't be considered full-screen for unredirecting screen.
 # unredir-if-possible-exclude = []
 
-# Use 'WM_TRANSIENT_FOR' to group windows, and consider windows 
+# Use 'WM_TRANSIENT_FOR' to group windows, and consider windows
 # in the same group focused at the same time.
 #
 # detect-transient = false
-detect-transient = true
+detect-transient = true;
 
-# Use 'WM_CLIENT_LEADER' to group windows, and consider windows in the same 
-# group focused at the same time. 'WM_TRANSIENT_FOR' has higher priority if 
+# Use 'WM_CLIENT_LEADER' to group windows, and consider windows in the same
+# group focused at the same time. 'WM_TRANSIENT_FOR' has higher priority if
 # detect-transient is enabled, too.
 #
 # detect-client-leader = false
-detect-client-leader = true
+detect-client-leader = true;
 
-# Resize damaged region by a specific number of pixels. 
-# A positive value enlarges it while a negative one shrinks it. 
-# If the value is positive, those additional pixels will not be actually painted 
-# to screen, only used in blur calculation, and such. (Due to technical limitations, 
-# with use-damage, those pixels will still be incorrectly painted to screen.) 
-# Primarily used to fix the line corruption issues of blur, 
-# in which case you should use the blur radius value here 
-# (e.g. with a 3x3 kernel, you should use `--resize-damage 1`, 
-# with a 5x5 one you use `--resize-damage 2`, and so on). 
+# Resize damaged region by a specific number of pixels.
+# A positive value enlarges it while a negative one shrinks it.
+# If the value is positive, those additional pixels will not be actually painted
+# to screen, only used in blur calculation, and such. (Due to technical limitations,
+# with use-damage, those pixels will still be incorrectly painted to screen.)
+# Primarily used to fix the line corruption issues of blur,
+# in which case you should use the blur radius value here
+# (e.g. with a 3x3 kernel, you should use `--resize-damage 1`,
+# with a 5x5 one you use `--resize-damage 2`, and so on).
 # May or may not work with *--glx-no-stencil*. Shrinking doesn't function correctly.
 #
 # resize-damage = 1
 
-# Specify a list of conditions of windows that should be painted with inverted color. 
+# Specify a list of conditions of windows that should be painted with inverted color.
 # Resource-hogging, and is not well tested.
 #
 # invert-color-include = []
 
-# GLX backend: Avoid using stencil buffer, useful if you don't have a stencil buffer. 
-# Might cause incorrect opacity when rendering transparent content (but never 
-# practically happened) and may not work with blur-background. 
+# GLX backend: Avoid using stencil buffer, useful if you don't have a stencil buffer.
+# Might cause incorrect opacity when rendering transparent content (but never
+# practically happened) and may not work with blur-background.
 # My tests show a 15% performance boost. Recommended.
 #
 # glx-no-stencil = false
 
-# GLX backend: Avoid rebinding pixmap on window damage. 
-# Probably could improve performance on rapid window content changes, 
+# GLX backend: Avoid rebinding pixmap on window damage.
+# Probably could improve performance on rapid window content changes,
 # but is known to break things on some drivers (LLVMpipe, xf86-video-intel, etc.).
 # Recommended if it works.
 #
 # glx-no-rebind-pixmap = false
 
-# Disable the use of damage information. 
+# Disable the use of damage information.
 # This cause the whole screen to be redrawn everytime, instead of the part of the screen
 # has actually changed. Potentially degrades the performance, but might fix some artifacts.
 # The opposing option is use-damage
 #
 # no-use-damage = false
-use-damage = true
+use-damage = true;
 
-# Use X Sync fence to sync clients' draw calls, to make sure all draw 
-# calls are finished before picom starts drawing. Needed on nvidia-drivers 
+# Use X Sync fence to sync clients' draw calls, to make sure all draw
+# calls are finished before picom starts drawing. Needed on nvidia-drivers
 # with GLX backend for some users.
 #
 # xrender-sync-fence = false
 
-# GLX backend: Use specified GLSL fragment shader for rendering window contents. 
-# See `compton-default-fshader-win.glsl` and `compton-fake-transparency-fshader-win.glsl` 
+# GLX backend: Use specified GLSL fragment shader for rendering window contents.
+# See `compton-default-fshader-win.glsl` and `compton-fake-transparency-fshader-win.glsl`
 # in the source tree for examples.
 #
-# glx-fshader-win = ''
+# glx-fshader-win = ""
 
-# Force all windows to be painted with blending. Useful if you 
+# Force all windows to be painted with blending. Useful if you
 # have a glx-fshader-win that could turn opaque pixels transparent.
 #
 # force-win-blend = false
 
-# Do not use EWMH to detect fullscreen windows. 
+# Do not use EWMH to detect fullscreen windows.
 # Reverts to checking if a window is fullscreen based only on its size and coordinates.
 #
 # no-ewmh-fullscreen = false
 
-# Dimming bright windows so their brightness doesn't exceed this set value. 
-# Brightness of a window is estimated by averaging all pixels in the window, 
-# so this could comes with a performance hit. 
+# Dimming bright windows so their brightness doesn't exceed this set value.
+# Brightness of a window is estimated by averaging all pixels in the window,
+# so this could comes with a performance hit.
 # Setting this to 1.0 disables this behaviour. Requires --use-damage to be disabled. (default: 1.0)
 #
 # max-brightness = 1.0
@@ -335,17 +335,17 @@ use-damage = true
 
 # Set the log level. Possible values are:
 #  "trace", "debug", "info", "warn", "error"
-# in increasing level of importance. Case doesn't matter. 
-# If using the "TRACE" log level, it's better to log into a file 
+# in increasing level of importance. Case doesn't matter.
+# If using the "TRACE" log level, it's better to log into a file
 # using *--log-file*, since it can generate a huge stream of logs.
 #
 # log-level = "debug"
 log-level = "warn";
 
 # Set the log file.
-# If *--log-file* is never specified, logs will be written to stderr. 
-# Otherwise, logs will to written to the given file, though some of the early 
-# logs might still be written to the stderr. 
+# If *--log-file* is never specified, logs will be written to stderr.
+# Otherwise, logs will to written to the given file, though some of the early
+# logs might still be written to the stderr.
 # When setting this option from the config file, it is recommended to use an absolute path.
 #
 # log-file = '/path/to/your/log/file'
@@ -357,33 +357,33 @@ log-level = "warn";
 # write-pid-path = '/path/to/your/log/file'
 
 # Window type settings
-# 
-# 'WINDOW_TYPE' is one of the 15 window types defined in EWMH standard: 
-#     "unknown", "desktop", "dock", "toolbar", "menu", "utility", 
-#     "splash", "dialog", "normal", "dropdown_menu", "popup_menu", 
+#
+# 'WINDOW_TYPE' is one of the 15 window types defined in EWMH standard:
+#     "unknown", "desktop", "dock", "toolbar", "menu", "utility",
+#     "splash", "dialog", "normal", "dropdown_menu", "popup_menu",
 #     "tooltip", "notification", "combo", and "dnd".
-# 
+#
 # Following per window-type options are available: ::
-# 
+#
 #   fade, shadow:::
 #     Controls window-type-specific shadow and fade settings.
-# 
+#
 #   opacity:::
 #     Controls default opacity of the window type.
-# 
+#
 #   focus:::
-#     Controls whether the window of this type is to be always considered focused. 
+#     Controls whether the window of this type is to be always considered focused.
 #     (By default, all window types except "normal" and "dialog" has this on.)
-# 
+#
 #   full-shadow:::
-#     Controls whether shadow is drawn under the parts of the window that you 
-#     normally won't be able to see. Useful when the window has parts of it 
+#     Controls whether shadow is drawn under the parts of the window that you
+#     normally won't be able to see. Useful when the window has parts of it
 #     transparent, and you want shadows in those areas.
-# 
+#
 #   redir-ignore:::
-#     Controls whether this type of windows should cause screen to become 
+#     Controls whether this type of windows should cause screen to become
 #     redirected again after been unredirected. If you have unredir-if-possible
-#     set, and doesn't want certain window to cause unnecessary screen redirection, 
+#     set, and doesn't want certain window to cause unnecessary screen redirection,
 #     you can set this to `true`.
 #
 wintypes:


### PR DESCRIPTION
This replaces single quotes for double quotes in the configuration
comments that refer to strings.
This was misleading since someone could took that comment as a valid
config entry, which is not.  One notable example was `backend = 'glx'`
which is not accepted by libconfig.

This also adds `;` for each default config values for consistency.

<!-- Please enable "Allow edits from maintainers" so we can make necessary changes to your PR -->
