### PR TITLE
Fix CodeQL warning

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -10,8 +10,8 @@
 
 #ifdef CONFIG_OPENGL
 #include <GL/gl.h>
-#include "backend/gl/glx.h"
 #include "backend/gl/gl_common.h"
+#include "backend/gl/glx.h"
 #endif
 
 #include "compiler.h"
@@ -160,9 +160,10 @@ attr_printf(4, 5) void log_printf(struct log *l, int level, const char *func,
 
 	struct timespec ts;
 	timespec_get(&ts, TIME_UTC);
-	auto tm = localtime(&ts.tv_sec);
+	struct tm now;
+	localtime_r(&ts.tv_sec, &now);
 	char time_buf[100];
-	strftime(time_buf, sizeof time_buf, "%x %T", tm);
+	strftime(time_buf, sizeof time_buf, "%x %T", &now);
 
 	char *time = NULL;
 	int tlen = asprintf(&time, "%s.%03ld", time_buf, ts.tv_nsec / 1000000);
@@ -335,7 +336,8 @@ struct gl_string_marker_logger {
 	PFNGLSTRINGMARKERGREMEDYPROC gl_string_marker;
 };
 
-static void gl_string_marker_logger_write(struct log_target *tgt, const char *str, size_t len) {
+static void
+gl_string_marker_logger_write(struct log_target *tgt, const char *str, size_t len) {
 	auto g = (struct gl_string_marker_logger *)tgt;
 	g->gl_string_marker((GLsizei)len, str);
 }


### PR DESCRIPTION
Fixes [CodeQL warning](https://github.com/yshui/picom/security/code-scanning/1) about use of non-thread-safe `localtime()`.

<!-- Please enable "Allow edits from maintainers" so we can make necessary changes to your PR -->
