### PR TITLE
Fix building on systems that define popcount in system headers

### DIFF
--- a/src/compiler.h
+++ b/src/compiler.h
@@ -98,6 +98,10 @@
 # define __has_include(x) 0
 #endif
 
+#ifndef popcount
+#define popcount(x) __builtin_popcount(x)
+#endif
+
 #if !defined(__STDC_NO_THREADS__) && __has_include(<threads.h>)
 # include <threads.h>
 #elif __STDC_VERSION__ >= 201112L
@@ -110,7 +114,3 @@
 
 typedef unsigned long ulong;
 typedef unsigned int uint;
-
-static inline int popcount(uint x) {
-	return __builtin_popcount(x);
-}

--- a/src/utils.h
+++ b/src/utils.h
@@ -136,9 +136,9 @@ static inline int attr_const normalize_i_range(int i, int min, int max) {
 /// clamp `val` into interval [min, max]
 #define clamp(val, min, max) max2(min2(val, max), min)
 
-static inline int attr_const popcountl(unsigned long a) {
-	return __builtin_popcountl(a);
-}
+#ifndef popcountl
+#define popcountl(x) __builtin_popcountl(x)
+#endif
 
 /**
  * Normalize a double value to a specific range.


### PR DESCRIPTION
Includes at least NetBSD: https://man.netbsd.org/popcount.3

~~~
In file included from ../src/log.h:8:0,
                 from ../src/backend/gl/glx.h:18,
                 from ../src/common.h:45,
                 from ../src/c2.c:36:
../src/compiler.h:114:19: error: conflicting types for ‘popcount’
 static inline int popcount(uint x) {
                   ^~~~~~~~
In file included from /usr/include/string.h:98:0,
                 from ../src/c2.c:16:
/usr/include/strings.h:57:14: note: previous declaration of ‘popcount’ was here
 unsigned int popcount(unsigned int) __constfunc;
              ^~~~~~~~
In file included from ../src/backend/gl/glx.h:20:0,
                 from ../src/common.h:45,
                 from ../src/c2.c:36:
../src/utils.h:139:30: error: conflicting types for ‘popcountl’
 static inline int attr_const popcountl(unsigned long a) {
                              ^~~~~~~~~
In file included from /usr/include/string.h:98:0,
                 from ../src/c2.c:16:
/usr/include/strings.h:58:14: note: previous declaration of ‘popcountl’ was here
 unsigned int popcountl(unsigned long) __constfunc;
              ^~~~~~~~~
~~~