### PR TITLE
x: remove the last bit of Xlib dependency

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -14,3 +14,6 @@ Checks: >
   -readability-magic-numbers
 AnalyzeTemporaryDtors: false
 FormatStyle:     file
+CheckOptions:
+  - key: readability-magic-numbers.IgnoredIntegerValues
+    value: 4;8;16;24;32;1;2;3;4096

--- a/src/atom.c
+++ b/src/atom.c
@@ -30,7 +30,8 @@ struct atom *init_atoms(xcb_connection_t *c) {
 	auto atoms = ccalloc(1, struct atom);
 	atoms->c = new_cache((void *)c, atom_getter, NULL);
 #define ATOM_GET(x) atoms->a##x = (xcb_atom_t)(intptr_t)cache_get(atoms->c, #x, NULL)
-	LIST_APPLY(ATOM_GET, SEP_COLON, ATOM_LIST);
+	LIST_APPLY(ATOM_GET, SEP_COLON, ATOM_LIST1);
+	LIST_APPLY(ATOM_GET, SEP_COLON, ATOM_LIST2);
 #undef ATOM_GET
 	return atoms;
 }

--- a/src/atom.h
+++ b/src/atom.h
@@ -8,7 +8,7 @@
 
 // clang-format off
 // Splitted into 2 lists because of the limitation of our macros
-#define ATOM_LIST \
+#define ATOM_LIST1 \
 	_NET_WM_WINDOW_OPACITY, \
 	_NET_FRAME_EXTENTS, \
 	WM_STATE, \
@@ -16,12 +16,16 @@
 	_NET_WM_PID, \
 	WM_NAME, \
 	WM_CLASS, \
+	WM_ICON_NAME, \
 	WM_TRANSIENT_FOR, \
 	WM_WINDOW_ROLE, \
 	WM_CLIENT_LEADER, \
+	WM_CLIENT_MACHINE, \
 	_NET_ACTIVE_WINDOW, \
 	_COMPTON_SHADOW, \
-	_NET_WM_WINDOW_TYPE, \
+	_NET_WM_WINDOW_TYPE
+
+#define ATOM_LIST2 \
 	_NET_WM_WINDOW_TYPE_DESKTOP, \
 	_NET_WM_WINDOW_TYPE_DOCK, \
 	_NET_WM_WINDOW_TYPE_TOOLBAR, \
@@ -38,14 +42,17 @@
 	_NET_WM_WINDOW_TYPE_DND, \
 	_NET_WM_STATE, \
 	_NET_WM_STATE_FULLSCREEN, \
-	_NET_WM_BYPASS_COMPOSITOR
+	_NET_WM_BYPASS_COMPOSITOR, \
+	UTF8_STRING, \
+	C_STRING
 // clang-format on
 
 #define ATOM_DEF(x) xcb_atom_t a##x
 
 struct atom {
 	struct cache *c;
-	LIST_APPLY(ATOM_DEF, SEP_COLON, ATOM_LIST);
+	LIST_APPLY(ATOM_DEF, SEP_COLON, ATOM_LIST1);
+	LIST_APPLY(ATOM_DEF, SEP_COLON, ATOM_LIST2);
 };
 
 struct atom *init_atoms(xcb_connection_t *);

--- a/src/c2.c
+++ b/src/c2.c
@@ -1406,8 +1406,9 @@ static inline void c2_match_once_leaf(session_t *ps, const struct managed_win *w
 				tgt_free = strdup(strlst[idx]);
 				tgt = tgt_free;
 			}
-			if (strlst)
-				XFreeStringList(strlst);
+			if (strlst) {
+				free(strlst);
+			}
 		}
 
 		if (tgt) {
@@ -1464,10 +1465,7 @@ static inline void c2_match_once_leaf(session_t *ps, const struct managed_win *w
 
 		// Free the string after usage, if necessary
 		if (tgt_free) {
-			if (C2_L_TATOM == pleaf->type)
-				XFree(tgt_free);
-			else
-				free(tgt_free);
+			free(tgt_free);
 		}
 	} break;
 	default: assert(0); break;
@@ -1557,6 +1555,7 @@ static bool c2_match_once(session_t *ps, const struct managed_win *w, const c2_p
  */
 bool c2_match(session_t *ps, const struct managed_win *w, const c2_lptr_t *condlst,
               void **pdata) {
+	assert(ps->server_grabbed);
 	// Then go through the whole linked list
 	for (; condlst; condlst = condlst->next) {
 		if (c2_match_once(ps, w, condlst->ptr)) {

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -6,6 +6,7 @@
 #include <stdc-predef.h>
 #endif
 
+// clang-format off
 #define auto           __auto_type
 #define likely(x)      __builtin_expect(!!(x), 1)
 #define unlikely(x)    __builtin_expect(!!(x), 0)
@@ -78,6 +79,12 @@
 # define attr_malloc
 #endif
 
+#if __has_attribute(fallthrough)
+# define fallthrough() __attribute__((fallthrough))
+#else
+# define fallthrough()
+#endif
+
 #if __STDC_VERSION__ >= 201112L
 # define attr_noret _Noreturn
 #else
@@ -107,6 +114,7 @@
 #else
 # define thread_local _Pragma("GCC error \"No thread local storage support\"") __error__
 #endif
+// clang-format on
 
 typedef unsigned long ulong;
 typedef unsigned int uint;

--- a/src/render.c
+++ b/src/render.c
@@ -1054,7 +1054,7 @@ void paint_all(session_t *ps, struct managed_win *t, bool ignore_damage) {
 		glXWaitX();
 		glx_render(ps, ps->tgt_buffer.ptex, 0, 0, 0, 0, ps->root_width,
 		           ps->root_height, 0, 1.0, false, false, &region, NULL);
-		// falls through
+		fallthrough();
 	case BKEND_GLX: glXSwapBuffers(ps->dpy, get_tgt_window(ps)); break;
 #endif
 	default: assert(0);

--- a/src/x.h
+++ b/src/x.h
@@ -73,6 +73,8 @@ struct xvisual_info {
 		__r;                                                                     \
 	})
 
+#define log_debug_x_error(e, fmt, ...)                                                   \
+	LOG(DEBUG, fmt " (%s)", ##__VA_ARGS__, x_strerror(e))
 #define log_error_x_error(e, fmt, ...)                                                   \
 	LOG(ERROR, fmt " (%s)", ##__VA_ARGS__, x_strerror(e))
 #define log_fatal_x_error(e, fmt, ...)                                                   \
@@ -145,6 +147,10 @@ xcb_window_t wid_get_prop_window(session_t *ps, xcb_window_t wid, xcb_atom_t apr
 
 /**
  * Get the value of a text property of a window.
+ *
+ * @param[out] pstrlst Out parameter for an array of strings, caller needs to free this
+ *                     array
+ * @param[out] pnstr   Number of strings in the array
  */
 bool wid_get_text_prop(session_t *ps, xcb_window_t wid, xcb_atom_t prop, char ***pstrlst,
                        int *pnstr);


### PR DESCRIPTION
Of course, we still use GLX, so we can't completely remove Xlib yet. But
this removes all Xlib uses outside of the backends.

Signed-off-by: Yuxuan Shui <yshuiv7@gmail.com>

<!-- Please enable "Allow edits from maintainers" so we can make necessary changes to your PR -->
