### PR TITLE
Add `--help` and `--toggle` options to `picom-trans`

### DIFF
--- a/bin/picom-trans
+++ b/bin/picom-trans
@@ -21,6 +21,8 @@
 #   $ picom-trans -c +5
 # Delete current window's opacity
 #   $ picom-trans -c --delete
+# Toggle current window's opacity between 90 and unset
+#   $ picom-trans -c --toggle 90
 # Reset all windows
 #   $ picom-trans --reset
 print_usage() {
@@ -35,6 +37,8 @@ print_usage() {
   echo "Actions:"
   echo "  -g, --get                 Print the target window's opacity."
   echo "  -d, --delete              Delete opacity of the target window."
+  echo "  -t, --toggle              Toggle the target window's opacity, i.e. set if not already set"
+  echo "                            and delete else."
   echo "  -r, --reset               Reset opacity for all windows."
   echo ""
   echo "Window Selection:"
@@ -87,10 +91,10 @@ while test $# -gt 0; do
   OPTIND=1
 
   # Read options
-  while getopts 'hscrdgn:w:o:-:' option "$@"; do
+  while getopts 'hscrtdgn:w:o:-:' option "$@"; do
     if test "$option" = '-'; then
       case "$OPTARG" in
-        help | select | current | reset | delete | get)
+        help | select | current | reset | toggle | delete | get)
           v=''
         ;;
         name | window | opacity)
@@ -117,6 +121,7 @@ while test $# -gt 0; do
         wprefix='-id'; window=$active
       ;;
       r) action='reset' ;;
+      t) action='toggle' ;;
       d) action='delete' ;;
       g) action='get' ;;
       n) wprefix='-name'; window=$OPTARG ;;
@@ -206,15 +211,17 @@ if test -z "$topmost"; then
   exit 1
 fi
 
+# Get current opacity.
+cur=$(xprop -id "$topmost" -notype _NET_WM_WINDOW_OPACITY \
+  | sed 's/^.*\b\([0-9]\+\).*$\|^.*$/\1/')
+
 # Remove the opacity property.
-if test x"$action" = x'delete'; then
+if test x"$action" = x'delete' -o \( x"$action" = x'toggle' -a -n "$cur" \); then
   xprop -id "$topmost" -remove _NET_WM_WINDOW_OPACITY
   exit 0
 fi
 
-# Get current opacity.
-cur=$(xprop -id "$topmost" -notype _NET_WM_WINDOW_OPACITY \
-  | sed 's/^.*\b\([0-9]\+\).*$\|^.*$/\1/')
+# Unset opacity equals fully opaque
 test -z "$cur" && cur=0xffffffff
 cur=$((cur * 100 / 0xffffffff))
 

--- a/bin/picom-trans
+++ b/bin/picom-trans
@@ -23,6 +23,26 @@
 #   $ picom-trans -c --delete
 # Reset all windows
 #   $ picom-trans --reset
+print_usage() {
+  echo "Usage: $0 [options] [+|-]opacity"
+  echo ""
+  echo "Options:"
+  echo "  -h, --help                Print this help message."
+  echo "  -o, --opacity OPACITY     Specify the new opacity value in range 1-100 for the window. If"
+  echo "                            prefixed with + or -, increment or decrement from the target"
+  echo "                            window’s current opacity."
+  echo ""
+  echo "Actions:"
+  echo "  -g, --get                 Print the target window's opacity."
+  echo "  -d, --delete              Delete opacity of the target window."
+  echo "  -r, --reset               Reset opacity for all windows."
+  echo ""
+  echo "Window Selection:"
+  echo "  -s, --select              Select target window with mouse cursor. (DEFAULT)"
+  echo "  -c, --current             Select the currently active window as target."
+  echo "  -n, --name WINDOW_NAME    Specify and try to match a window name."
+  echo "  -w, --window WINDOW_ID    Specify the window id of the target window."
+}
 
 case "$0" in
   *compton-trans*)  echo "Warning: compton has been renamed, please use picom-trans instead" >& 2;;
@@ -31,6 +51,11 @@ esac
 # "command" is a shell built-in, faster than "which"
 if test -z "$(command -v xprop)" -o -z "$(command -v xwininfo)"; then
   echo 'The command xwininfo or xprop is not available. They might reside in a package named xwininfo, xprop, x11-utils, xorg-xprop, or xorg-xwininfo.' >& 2
+  exit 1
+fi
+
+if test $# -eq 0; then
+  print_usage >& 2
   exit 1
 fi
 
@@ -62,10 +87,10 @@ while test $# -gt 0; do
   OPTIND=1
 
   # Read options
-  while getopts 'scrdgn:w:o:-:' option "$@"; do
+  while getopts 'hscrdgn:w:o:-:' option "$@"; do
     if test "$option" = '-'; then
       case "$OPTARG" in
-        select | current | reset | delete | get)
+        help | select | current | reset | delete | get)
           v=''
         ;;
         name | window | opacity)
@@ -84,6 +109,7 @@ while test $# -gt 0; do
       OPTARG=$v
     fi
     case "$option" in
+      h) print_usage; exit 0 ;;
       s) wprefix=''; window='' ;;
       c)
         active=$(xprop -root -notype _NET_ACTIVE_WINDOW \

--- a/man/picom-trans.1.asciidoc
+++ b/man/picom-trans.1.asciidoc
@@ -42,6 +42,9 @@ Print the target window's opacity instead of setting it.
 *-d*, *--delete*::
 Delete opacity of the target window instead of setting it.
 
+*-t*, *--toggle*::
+Toggle the target window's opacity: Set opacity if not already set, and delete if already set.
+
 *-r*, *--reset*::
 Reset opacity for all windows instead of setting it.
 
@@ -88,6 +91,12 @@ picom-trans -c -- -5
 +
 ------------
 picom-trans -c --delete
+------------
+
+* Toggle current window's opacity between 90 and unset
++
+------------
+picom-trans -c --toggle 90
 ------------
 
 * Reset all windows:

--- a/man/picom-trans.1.asciidoc
+++ b/man/picom-trans.1.asciidoc
@@ -21,20 +21,29 @@ DESCRIPTION
 
 OPTIONS
 -------
-*-w* 'WINDOW_ID'::
+*-w*, *--window*='WINDOW_ID'::
 Specify the window id of the target window.
 
-*-n* 'WINDOW_NAME'::
+*-n*, *--name*='WINDOW_NAME'::
 Specify and try to match a window name.
 
-*-c*::
+*-c*, *--current*::
 Specify the currently active window as target. Only works if EWMH '_NET_ACTIVE_WINDOW' property exists on root window.
 
-*-s*::
+*-s*, *--select*::
 Select target window with mouse cursor. This is the default if no window has been specified.
 
-*-o* 'OPACITY'::
-Specify the new opacity value for the window. This value can be anywhere from 1-100. If it is prefixed with a plus or minus (+/-), this will increment or decrement from the target window's current opacity instead. 
+*-o*, *--opacity*='OPACITY'::
+Specify the new opacity value for the window. This value can be anywhere from 1-100. If it is prefixed with a plus or minus (+/-), this will increment or decrement from the target window's current opacity instead.
+
+*-g*, *--get*::
+Print the target window's opacity instead of setting it.
+
+*-d*, *--delete*::
+Delete opacity of the target window instead of setting it.
+
+*-r*, *--reset*::
+Reset opacity for all windows instead of setting it.
 
 EXAMPLES
 --------
@@ -73,6 +82,18 @@ picom-trans -c +5
 +
 ------------
 picom-trans -c -- -5
+------------
+
+* Delete current window's opacity:
++
+------------
+picom-trans -c --delete
+------------
+
+* Reset all windows:
++
+------------
+picom-trans --reset
 ------------
 
 BUGS


### PR DESCRIPTION
<!-- Please enable "Allow edits from maintainers" so we can make necessary changes to your PR -->
* Add new option `-h, --help` to `picom-trans` to print a help message with all supported options (see #513). Updated the manpage to reflect all supported options as well.
* Add new action `-t, --toggle` to `picom-trans` to toggle between set opacity and delete opacity — i.e. unset (see #472).