### PR TITLE
More delayed event handlings

### DIFF
--- a/src/win.h
+++ b/src/win.h
@@ -314,7 +314,7 @@ void win_recheck_client(session_t *ps, struct managed_win *w);
  */
 double attr_pure win_calc_opacity_target(session_t *ps, const struct managed_win *w);
 bool attr_pure win_should_dim(session_t *ps, const struct managed_win *w);
-void win_update_screen(session_t *, struct managed_win *);
+void win_update_screen(int nscreens, region_t *screens, struct managed_win *w);
 /**
  * Retrieve the bounding shape of a window.
  */

--- a/src/win_defs.h
+++ b/src/win_defs.h
@@ -87,6 +87,10 @@ enum win_flags {
 	WIN_FLAGS_MAPPED = 64,
 	/// this window has properties which needs to be updated
 	WIN_FLAGS_PROPERTY_STALE = 128,
+	/// this window has an unhandled size/shape change
+	WIN_FLAGS_SIZE_STALE = 256,
+	/// need better name for this, is set when some aspects of the window changed
+	WIN_FLAGS_FACTOR_CHANGED = 512,
 };
 
 static const uint64_t WIN_FLAGS_IMAGES_STALE =


### PR DESCRIPTION
Part of the configure notify handling which requires querying the X
server, has been moved into the X critical section.

Signed-off-by: Yuxuan Shui <yshuiv7@gmail.com>

<!-- Please enable "Allow edits from maintainers" so we can make necessary changes to your PR -->
