### PR TITLE
Fix/silence memory errors reported by `scan-build`.

### DIFF
--- a/src/c2.c
+++ b/src/c2.c
@@ -265,7 +265,8 @@ static inline void c2_ptr_reset(c2_ptr_t *pp) {
  * Combine two condition trees.
  */
 static inline c2_ptr_t c2h_comb_tree(c2_b_op_t op, c2_ptr_t p1, c2_ptr_t p2) {
-	c2_ptr_t p = {.isbranch = true, .b = cmalloc(c2_b_t)};
+	c2_ptr_t p = {.isbranch = true, .b = NULL};
+	p.b = cmalloc(c2_b_t);
 
 	p.b->neg = false;
 	p.b->op = op;

--- a/src/picom.c
+++ b/src/picom.c
@@ -2515,6 +2515,7 @@ int main(int argc, char **argv) {
 	if (pid_file) {
 		log_trace("remove pid file %s", pid_file);
 		unlink(pid_file);
+		free(pid_file);
 	}
 
 	log_deinit_tls();


### PR DESCRIPTION
- Fix non-critical memory-leak in `picom.c` and `options.c` where we don't free all allocated memory before dieing.

- Explicitly allocate new branch in `c2.c` to silence false-positive memory-leak.

<!-- Please enable "Allow edits from maintainers" so we can make necessary changes to your PR -->
