### PR TITLE
[nitpicking] silencing some warnings

### DIFF
--- a/src/picom.c
+++ b/src/picom.c
@@ -101,7 +101,7 @@ const char *const BACKEND_STRS[] = {[BKEND_XRENDER] = "xrender",
 session_t *ps_g = NULL;
 
 void set_root_flags(session_t *ps, uint64_t flags) {
-	log_debug("Setting root flags: %lu", flags);
+	log_debug("Setting root flags: %" PRIu64, flags);
 	ps->root_flags |= flags;
 	ps->pending_updates = true;
 }

--- a/src/win.c
+++ b/src/win.c
@@ -240,7 +240,7 @@ void win_get_region_frame_local(const struct managed_win *w, region_t *res) {
 
 	// limit the frame region to inside the window
 	region_t reg_win;
-	pixman_region32_init_rects(&reg_win, (rect_t[]){0, 0, outer_width, outer_height}, 1);
+	pixman_region32_init_rects(&reg_win, (rect_t[]){{0, 0, outer_width, outer_height}}, 1);
 	pixman_region32_intersect(res, &reg_win, res);
 	pixman_region32_fini(&reg_win);
 }

--- a/src/win.c
+++ b/src/win.c
@@ -4,6 +4,7 @@
 
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
+#include <inttypes.h>
 #include <math.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -2515,7 +2516,7 @@ win_is_fullscreen_xcb(xcb_connection_t *c, const struct atom *a, const xcb_windo
 
 /// Set flags on a window. Some sanity checks are performed
 void win_set_flags(struct managed_win *w, uint64_t flags) {
-	log_debug("Set flags %lu to window %#010x (%s)", flags, w->base.id, w->name);
+	log_debug("Set flags %" PRIu64 " to window %#010x (%s)", flags, w->base.id, w->name);
 	if (unlikely(w->state == WSTATE_DESTROYING)) {
 		log_error("Flags set on a destroyed window %#010x (%s)", w->base.id, w->name);
 		return;
@@ -2526,7 +2527,8 @@ void win_set_flags(struct managed_win *w, uint64_t flags) {
 
 /// Clear flags on a window. Some sanity checks are performed
 void win_clear_flags(struct managed_win *w, uint64_t flags) {
-	log_debug("Clear flags %lu from window %#010x (%s)", flags, w->base.id, w->name);
+	log_debug("Clear flags %" PRIu64 " from window %#010x (%s)", flags, w->base.id,
+	          w->name);
 	if (unlikely(w->state == WSTATE_DESTROYING)) {
 		log_warn("Flags cleared on a destroyed window %#010x (%s)", w->base.id,
 		         w->name);


### PR DESCRIPTION
hello there,

I know, this is some hardcore nitpicking, so feel free to ignore it.

While building the latest release I got annoyed by the warnings and decided to fix them.  Turns out, 99% of the warnings I get are due to uthash' macro (missing fallthrough annotation in particular), so this pr fixes only the remaining 1%: three wrong format string for uint64_t and a missing brace (in clang opinion).  Now, if I build with -Wno-implicit-fallthrough there aren't warnings, yeee!

Regarding the format string: on my system uint64_t is long long unsigned int, but maybe that's not the case everywhere? In doubt, I used the PRI macros from inttypes.h

edit: sorry if I messed up when creating the pr.  Now it should be as intended.