### PR TITLE
Cast argument to ctype functions to unsigned char

### DIFF
--- a/src/c2.c
+++ b/src/c2.c
@@ -240,7 +240,7 @@ static inline int strcmp_wd(const char *needle, const char *src) {
 		return ret;
 
 	char c = src[strlen(needle)];
-	if (isalnum(c) || '_' == c)
+	if (isalnum((unsigned char)c) || '_' == c)
 		return 1;
 	else
 		return 0;
@@ -387,7 +387,7 @@ c2_lptr_t *c2_parse(c2_lptr_t **pcondlst, const char *pattern, void *data) {
 // TODO(yshui) Not a very good macro, should probably be a function
 #define C2H_SKIP_SPACES()                                                                \
 	{                                                                                \
-		while (isspace(pattern[offset]))                                         \
+		while (isspace((unsigned char)pattern[offset]))                          \
 			++offset;                                                        \
 	}
 
@@ -431,7 +431,7 @@ static int c2_parse_grp(const char *pattern, int offset, c2_ptr_t *presult, int 
 		assert(elei <= 2);
 
 		// Jump over spaces
-		if (isspace(pattern[offset]))
+		if (isspace((unsigned char)pattern[offset]))
 			continue;
 
 		// Handle end of group
@@ -579,7 +579,8 @@ static int c2_parse_target(const char *pattern, int offset, c2_ptr_t *presult) {
 
 	// Copy target name out
 	int tgtlen = 0;
-	for (; pattern[offset] && (isalnum(pattern[offset]) || '_' == pattern[offset]);
+	for (; pattern[offset] &&
+	       (isalnum((unsigned char)pattern[offset]) || '_' == pattern[offset]);
 	     ++offset) {
 		++tgtlen;
 	}
@@ -826,7 +827,7 @@ static int c2_parse_pattern(const char *pattern, int offset, c2_ptr_t *presult) 
 		pleaf->ptntype = C2_L_PTINT;
 		offset = to_int_checked(endptr - pattern);
 		// Make sure we are stopping at the end of a word
-		if (isalnum(pattern[offset])) {
+		if (isalnum((unsigned char)pattern[offset])) {
 			c2_error("Trailing characters after a numeric pattern.");
 		}
 	} else {
@@ -835,7 +836,7 @@ static int c2_parse_pattern(const char *pattern, int offset, c2_ptr_t *presult) 
 		char delim = '\0';
 
 		// String flags
-		if (tolower(pattern[offset]) == 'r') {
+		if (tolower((unsigned char)pattern[offset]) == 'r') {
 			raw = true;
 			++offset;
 			C2H_SKIP_SPACES();
@@ -1034,7 +1035,7 @@ static bool c2_l_postprocess(session_t *ps, c2_l_t *pleaf) {
 	// Warn about lower case characters in target name
 	if (pleaf->predef == C2_L_PUNDEFINED) {
 		for (const char *pc = pleaf->tgt; *pc; ++pc) {
-			if (islower(*pc)) {
+			if (islower((unsigned char)*pc)) {
 				log_warn("Lowercase character in target name \"%s\".",
 				         pleaf->tgt);
 				break;

--- a/src/config.c
+++ b/src/config.c
@@ -33,7 +33,7 @@ bool parse_long(const char *s, long *dest) {
 		log_error("Invalid number: %s", s);
 		return false;
 	}
-	while (isspace(*endptr))
+	while (isspace((unsigned char)*endptr))
 		++endptr;
 	if (*endptr) {
 		log_error("Trailing characters: %s", s);
@@ -74,7 +74,7 @@ const char *parse_readnum(const char *src, double *dest) {
 		log_error("No number found: %s", src);
 		return src;
 	}
-	while (*pc && (isspace(*pc) || *pc == ',')) {
+	while (*pc && (isspace((unsigned char)*pc) || *pc == ',')) {
 		++pc;
 	}
 	*dest = val;
@@ -161,7 +161,7 @@ conv *parse_blur_kern(const char *src, const char **endptr, bool *hasneg) {
 
 	// Detect trailing characters
 	for (; *pc && *pc != ';'; pc++) {
-		if (!isspace(*pc) && *pc != ',') {
+		if (!isspace((unsigned char)*pc) && *pc != ',') {
 			// TODO(yshui) isspace is locale aware, be careful
 			log_error("Trailing characters in blur kernel string.");
 			goto err2;
@@ -171,7 +171,7 @@ conv *parse_blur_kern(const char *src, const char **endptr, bool *hasneg) {
 	// Jump over spaces after ';'
 	if (*pc == ';') {
 		pc++;
-		while (*pc && isspace(*pc)) {
+		while (*pc && isspace((unsigned char)*pc)) {
 			++pc;
 		}
 	}
@@ -425,7 +425,7 @@ bool parse_rule_opacity(c2_lptr_t **res, const char *src) {
 	}
 
 	// Skip over spaces
-	while (*endptr && isspace(*endptr))
+	while (*endptr && isspace((unsigned char)*endptr))
 		++endptr;
 	if (':' != *endptr) {
 		log_error("Opacity terminator not found: %s", src);

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -129,7 +129,7 @@ bool cdbus_init(session_t *ps, const char *uniq) {
 		// underscore
 		char *tmp = service + strlen(CDBUS_SERVICE_NAME) + 1;
 		while (*tmp) {
-			if (!isalnum(*tmp)) {
+			if (!isalnum((unsigned char)*tmp)) {
 				*tmp = '_';
 			}
 			tmp++;
@@ -226,7 +226,8 @@ typedef struct ev_dbus_timer {
 /**
  * Callback for handling a D-Bus timeout.
  */
-static void cdbus_callback_handle_timeout(EV_P attr_unused, ev_timer *w, int revents attr_unused) {
+static void
+cdbus_callback_handle_timeout(EV_P attr_unused, ev_timer *w, int revents attr_unused) {
 	ev_dbus_timer *t = (void *)w;
 	dbus_timeout_handle(t->t);
 }

--- a/src/string_utils.h
+++ b/src/string_utils.h
@@ -37,7 +37,7 @@ static inline int uitostr(unsigned int n, char *buf) {
 static inline const char *skip_space_const(const char *src) {
 	if (!src)
 		return NULL;
-	while (*src && isspace(*src))
+	while (*src && isspace((unsigned char)*src))
 		src++;
 	return src;
 }
@@ -45,7 +45,7 @@ static inline const char *skip_space_const(const char *src) {
 static inline char *skip_space_mut(char *src) {
 	if (!src)
 		return NULL;
-	while (*src && isspace(*src))
+	while (*src && isspace((unsigned char)*src))
 		src++;
 	return src;
 }


### PR DESCRIPTION
Per POSIX, "The c argument is an int, the value of which the application shall ensure is a character representable as an unsigned char or equal to the value of the macro EOF. If the argument has any other value, the behavior is undefined."

https://pubs.opengroup.org/onlinepubs/009604499/functions/isspace.html