### PR TITLE
set .desktop files to "NoDisplay=true"

### DIFF
--- a/compton.desktop
+++ b/compton.desktop
@@ -1,6 +1,7 @@
 [Desktop Entry]
 Version=1.0
 Type=Application
+NoDisplay=true
 Name=compton
 GenericName=X compositor
 Comment=An X compositor

--- a/picom-dbus.desktop
+++ b/picom-dbus.desktop
@@ -1,6 +1,7 @@
 [Desktop Entry]
 Version=1.0
 Type=Application
+NoDisplay=true
 Name=picom (dbus)
 GenericName=X compositor (dbus)
 Comment=An X compositor with dbus backend enabled

--- a/picom.desktop
+++ b/picom.desktop
@@ -1,6 +1,7 @@
 [Desktop Entry]
 Version=1.0
 Type=Application
+NoDisplay=true
 Name=picom
 GenericName=X compositor
 Comment=An X compositor


### PR DESCRIPTION
This set "NoDisplay=true" in `picom.desktop`, `compton.desktop` and `picom-dbus.desktop`.

This will hide them by default on most "application menus"  which makes sense since in most case they should not be launched manually anyway.
This was actually proposed back in the [original issue](https://github.com/chjj/compton/issues/97) but for some reason it was not added to the commit.

[Desktop Entry Specification#Recognized desktop entry keys](https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s06.html)