### PR TITLE
Add packages needed for building on Fedora to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,16 @@ Assuming you already have all the usual building tools installed (e.g. gcc, pyth
 * libev
 * uthash
 
-On Debian based distributions (e.g. Ubuntu), the list of needed packages are
+On Debian based distributions (e.g. Ubuntu), the needed packages are
 
 ```
 libxext-dev libxcb1-dev libxcb-damage0-dev libxcb-xfixes0-dev libxcb-shape0-dev libxcb-render-util0-dev libxcb-render0-dev libxcb-randr0-dev libxcb-composite0-dev libxcb-image0-dev libxcb-present-dev libxcb-xinerama0-dev libxcb-glx0-dev libpixman-1-dev libdbus-1-dev libconfig-dev libgl1-mesa-dev libpcre2-dev libpcre3-dev libevdev-dev uthash-dev libev-dev libx11-xcb-dev
+```
+
+On Fedora, the needed packages are
+
+```
+dbus-devel gcc git libconfig-devel libdrm-devel libev-devel libX11-devel libX11-xcb libXext-devel libxcb-devel mesa-libGL-devel meson pcre-devel pixman-devel uthash-devel xcb-util-image-devel xcb-util-renderutil-devel xorg-x11-proto-devel
 ```
 
 To build the documents, you need `asciidoc`


### PR DESCRIPTION
I just spent some time looking up all the package names required to build picom on Fedora. This would add this to the README.

To confirm that this is enough for building (at least on Fedora 33), create a `Dockerfile` with the following:

```Dockerfile
FROM fedora:33
WORKDIR /picom
RUN dnf -y install \
    asciidoc \
    dbus-devel \
    gcc \
    git \
    libconfig-devel \
    libdrm-devel \
    libev-devel \
    libX11-devel \
    libX11-xcb \
    libXext-devel \
    libxcb-devel \
    mesa-libGL-devel \
    meson \
    pcre-devel \
    pixman-devel \
    uthash-devel \
    xcb-util-image-devel \
    xcb-util-renderutil-devel \
    xorg-x11-proto-devel
```

and run:

```sh
docker build -t picom-build . && docker run --rm -v $PWD/out:/out:Z picom-build bash -c "\
    git clone https://github.com/yshui/picom/ /picom && \
    git submodule update --init --recursive && \
    meson --buildtype=release -Dprefix=/out -Dvsync_drm=true -Dwith_docs=true . build && \
    ninja -C build install \
    "
```

I'm fairly certain that this list is also the minimum needed amount of packages, since I was careful to not include anything unnecessary.