### PR TITLE
circleci: rename "-Dbuild_docs" -> "-Dwith_docs"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
     executor: e
     steps:
       - build:
-          build-config: -Dbuild_docs=true -Db_coverage=true
+          build-config: -Dwith_docs=true -Db_coverage=true
       - persist_to_workspace:
           root: .
           paths:


### PR DESCRIPTION
While investigating why the docs where not being build in NixOS (see https://github.com/NixOS/nixpkgs/pull/108530), I discovered that the flag to build docs changed, but there is one place in the code that still used the old flag.

This was renamed in commit 3f2a671, but I think it was simply forgotten in CI.

<!-- Please enable "Allow edits from maintainers" so we can make necessary changes to your PR -->
