### PR TITLE
Set GL_MaxFramesAllowed=1 instead of GL_YIELD=usleep

### DIFF
--- a/src/backend/driver.c
+++ b/src/backend/driver.c
@@ -15,7 +15,8 @@
 /// Apply driver specified global workarounds. It's safe to call this multiple times.
 void apply_driver_workarounds(struct session *ps, enum driver driver) {
 	if (driver & DRIVER_NVIDIA) {
-		setenv("__GL_YIELD", "usleep", true);
+		// setenv("__GL_YIELD", "usleep", true);
+		setenv("__GL_MaxFramesAllowed", "1", true);
 		ps->o.xrender_sync_fence = true;
 	}
 }

--- a/src/backend/gl/glx.c
+++ b/src/backend/gl/glx.c
@@ -467,7 +467,9 @@ static void glx_present(backend_t *base, const region_t *region attr_unused) {
 	struct _glx_data *gd = (void *)base;
 	gl_present(base, region);
 	glXSwapBuffers(gd->display, gd->target_win);
-	glFinish();
+	if (!gd->gl.is_nvidia) {
+		glFinish();
+	}
 }
 
 static int glx_buffer_age(backend_t *base) {


### PR DESCRIPTION
This essentially concludes my issue #592, implementing the original change mentioned in my first post (instead of the other, later implementations I tried, which in the time since, I've decided they were only marginal improvements, with testing ultimately being inconclusive - at a cost of (personally) unacceptable amount of changes to the code/code separation.*)

_*I'll mention more about the "inconclusive testing" later, for anyone reading this and thinking the ideas mentioned in #592 have some merit. Which I do still think they have, but the cost of implementation is high. High enough that I no longer think it is practical. A hardware upgrade, honestly, might be more practical (compared to more consistent 59-60Hz if fixed - as the smoothness issue with picom really only affects 60Hz and lower displays) given how much more afforable high refresh rate displays have become recently._

I have conclusive data this time from testing with NVIDIA's Nsight Systems. Nothing too major in terms of improvements - other than much-reduced max frame times (~63-82ms -> ~19-25ms, on a 160Hz display) and a bit less CPU time - but I think it is enough to warrant the changes.

I will preface this by saying that I still don't quite understand why we're (specifically) using USLEEP. I am aware of why it was needed - since glFinish busy-waits and causes high CPU utilization - but I'm unsure why disabling triple buffering (with this MaxFramesAllowed flag) was not considered as an alternative, as this essentially renders glFinish a dummy call that returns immediately and forces the swap buffers command to always block/wait until vertical refresh (which is the same result we appear to be trying to achieve with glFinish).

Anyways, the data:

**Testing notes:**
- I managed to do the testing on a Ryzen 9 5950x, RTX 3090 system running a 3440x1440 160Hz ultrawide display **(with G-Sync enabled)**, so the differences in testing below I'm quite sure are not related to the hardware (other than perhaps picom struggling a bit more with the ultrawide resolution. I have tested (seperately) that picom is capable of running 160Hz at native resolution at idle/light tasks though)
- **The test (ran twice):** Quickly dragging a floating instance of kitty terminal (in a random/erratic fashion) over a playing 60Hz YouTube video in Chrome, on i3wm. This seems to be the best way of forcing as many redraws as possible, with real-world noticeable differences (since I + some other issues have mentioned noticing "laggy" floating windows while a video is playing in the background. Though, on second thought, I could also try doing something similar from Blurbusters + while dragging a floating window later)
- **Launch command:** picom --experimental-backends --benchmark 2400 _(Note: 2400 is benchmarking 2400 frames or roughly 15s assuming we can maintain 160Hz)_

**picom next branch (GL_YIELD=usleep)**
![image](https://user-images.githubusercontent.com/16279847/122484938-c2d09300-cfa3-11eb-866c-360eed9a9a6a.png)
![image](https://user-images.githubusercontent.com/16279847/122484976-e0056180-cfa3-11eb-9e11-3a2e152641db.png)

**Note:** Yellow colored frames seem to indicate that they took slightly longer than ~16.6 ms i.e. 1 frame under 60Hz. Not sure why this is the default color coding from Nvidia - I don't see any options to change this in Nsight either, unfortunately. Red colored frames are ones which took 2-3 frames under 60Hz to render (i.e. ~40-50ms).

**picom next branch with GL_MaxFramesAllowed=1**
![image](https://user-images.githubusercontent.com/16279847/122485359-aaad4380-cfa4-11eb-84d4-89a0185a73a6.png)
![image](https://user-images.githubusercontent.com/16279847/122485370-b13bbb00-cfa4-11eb-89bf-a606758b7e59.png)

Overall frame-rate is higher here, with lower average frame times and much lower max-frame times. Frame stability is also much improved (no red-coloured frames at all, with only a few yellow-coloured ones). ~~While CPU utlization seems to be higher~~*, we seem to be spending that time using actual useful work (instead of calling usleep every few ms). Randomly observing a selection of frames from both reports seem to confirm this:

_*Thought this might have been caused by the changes, but on second thought - after examining a few more selections of frames, they both seem to be about the same, minus time spent calling usleep._

**picom next branch (selection of 8 frames)**
![image](https://user-images.githubusercontent.com/16279847/122485976-222fa280-cfa6-11eb-921d-cb563d6fd54e.png)

**picom next branch with MaxFramesAllowed (8 frames)**
![image](https://user-images.githubusercontent.com/16279847/122486862-e4cc1480-cfa7-11eb-9be1-319336088218.png)

EDIT: Hmm, just noticed this, but it appears Nsight is saying I selected 10 CPU frames... except I'm not seeing where it counts 10. (Looks like 8 to me).

**picom 8.2**
Also, for fun (and also b/c I forgot that the current picom release version is still 8.2 and installed the wrong version), picom 8.2. This has, by far, the worst results - but I think it's mostly due to the new changes to floating window movement that I believe were introduced after version 8.2 (which of course benefit the results of the post-8.2 builds)

![image](https://user-images.githubusercontent.com/16279847/122486392-fcef6400-cfa6-11eb-890c-cb6b8dd857dd.png)
![image](https://user-images.githubusercontent.com/16279847/122486405-037ddb80-cfa7-11eb-852e-228c0171bebe.png)

______________________________

As a final note, I do have the report files created by Nsight and originally planned to upload them, but unfortunately they only seem to be able to opened by Nsight, with no viable export options that provide the same readability. @yshui, please let me know if you or others want a copy of the files (if you have Nsight installed), as well as the best place to upload them to (for best ease of access).

EDIT: Also, forgot to mention. This is just one testing result, from one system. More testing is of course needed! (to see if there are really benefits from making this change). If anyone else can testing using Nsight (requires registering an NVIDIA Developer account, but the process was relatively simple IIRC), those results would be quite valuable as well.

(And, of course, this fix only affects NVIDIA GPUs since the original GL_YIELD=usleep flag setting is also a fix specific to when NVIDIA drivers are detected)