### PR TITLE
nvidia driver does not support attaching pixmap texture to fbo

### DIFF
--- a/src/backend/gl/gl_common.h
+++ b/src/backend/gl/gl_common.h
@@ -136,6 +136,14 @@ static inline const char *gl_get_err_str(GLenum err) {
 		CASESTRRET(GL_OUT_OF_MEMORY);
 		CASESTRRET(GL_STACK_UNDERFLOW);
 		CASESTRRET(GL_STACK_OVERFLOW);
+		CASESTRRET(GL_FRAMEBUFFER_UNDEFINED);
+		CASESTRRET(GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT);
+		CASESTRRET(GL_FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT);
+		CASESTRRET(GL_FRAMEBUFFER_INCOMPLETE_DRAW_BUFFER);
+		CASESTRRET(GL_FRAMEBUFFER_INCOMPLETE_READ_BUFFER);
+		CASESTRRET(GL_FRAMEBUFFER_UNSUPPORTED);
+		CASESTRRET(GL_FRAMEBUFFER_INCOMPLETE_MULTISAMPLE);
+		CASESTRRET(GL_FRAMEBUFFER_INCOMPLETE_LAYER_TARGETS);
 	}
 	return NULL;
 }
@@ -166,6 +174,30 @@ static inline void gl_clear_err(void) {
 }
 
 #define gl_check_err() gl_check_err_(__func__, __LINE__)
+
+/**
+ * Check for GL framebuffer completeness.
+ */
+static inline bool gl_check_fb_complete_(const char *func, int line, GLenum fb) {
+	GLenum status = glCheckFramebufferStatus(fb);
+
+	if (status == GL_FRAMEBUFFER_COMPLETE) {
+		return true;
+	}
+
+	const char *stattext = gl_get_err_str(status);
+	if (stattext) {
+		log_printf(tls_logger, LOG_LEVEL_ERROR, func,
+		           "Framebuffer attachment failed at line %d: %s", line, stattext);
+	} else {
+		log_printf(tls_logger, LOG_LEVEL_ERROR, func,
+		           "Framebuffer attachment failed at line %d: %d", line, status);
+	}
+
+	return false;
+}
+
+#define gl_check_fb_complete(fb) gl_check_fb_complete_(__func__, __LINE__, (fb))
 
 /**
  * Check if a GLX extension exists.


### PR DESCRIPTION
The (proprietary) NVIDIA driver apparently does not support attaching textures that are bound to a glx pixmap to a framebuffer object. Doing so fails the framebuffer-completeness test with `GL_FRAMEBUFFER_UNSUPPORTED`.
AMD and Intel seems to not be affected: https://github.com/yshui/picom/issues/647#issuecomment-867746911, https://github.com/yshui/picom/issues/647#issuecomment-867966401

Partially reverts `gl_image_decouple()` in 2a60836a9bc30d92b4adb46d5f48684a5d2f1ecb:
Instead of binding the source texture to a framebuffer and then copying with `glTexImage2D()`, bind the destination texture to the framebuffer and copy the source texture with a simple quad-rending.

Also includes more detailed error messages should a framebuffer not be complete.

fixes: #645, #647