### PR TITLE
Do not try to ignore xerrors before session is initialized

### DIFF
--- a/src/picom.c
+++ b/src/picom.c
@@ -298,6 +298,10 @@ void discard_ignore(session_t *ps, unsigned long sequence) {
 }
 
 static int should_ignore(session_t *ps, unsigned long sequence) {
+	if (ps == NULL) {
+		// Do not ignore errors until the session has been initialized
+		return false;
+	}
 	discard_ignore(ps, sequence);
 	return ps->ignore_head && ps->ignore_head->sequence == sequence;
 }
@@ -907,8 +911,9 @@ void root_damaged(session_t *ps) {
  * Xlib error handler function.
  */
 static int xerror(Display attr_unused *dpy, XErrorEvent *ev) {
-	if (!should_ignore(ps_g, ev->serial))
+	if (!should_ignore(ps_g, ev->serial)) {
 		x_print_error(ev->serial, ev->request_code, ev->minor_code, ev->error_code);
+	}
 	return 0;
 }
 
@@ -916,8 +921,9 @@ static int xerror(Display attr_unused *dpy, XErrorEvent *ev) {
  * XCB error handler function.
  */
 void ev_xcb_error(session_t *ps, xcb_generic_error_t *err) {
-	if (!should_ignore(ps, err->sequence))
+	if (!should_ignore(ps, err->sequence)) {
 		x_print_error(err->sequence, err->major_code, err->minor_code, err->error_code);
+	}
 }
 
 /**


### PR DESCRIPTION
If the user has no access to the GPU, initialization of the GLX context fails. In the legacy backend, this occurs BEFORE the session has been successfully initialized, triggering an XError.
At this point we cannot meaningfully filter XErrors as the session hasn't been initialized yet. Trying to filter triggers a SEGFAULT in `discard_ignore()`.

So for as long as the session is not initialized we do not try to filter out any errors.

@yshui are you okay with this solution or would you like the `!= NULL` check to be in `should_ignore()` instead?