### PR TITLE
Fix non-transparent frames for opaque windows in experimental xrender backend

### DIFF
--- a/src/backend/xrender/xrender.c
+++ b/src/backend/xrender/xrender.c
@@ -512,8 +512,12 @@ static bool decouple_image(backend_t *base, struct backend_image *img, const reg
 		return true;
 	}
 	auto inner = (struct _xrender_image_data_inner *)img->inner;
-	auto inner2 =
-	    new_inner(base, inner->width, inner->height, inner->visual, inner->depth);
+	// Force new pixmap to a 32-bit ARGB visual to allow for transparent frames around
+	// non-transparent windows
+	auto visual = (inner->depth == 32)
+	                  ? inner->visual
+	                  : x_get_visual_for_standard(base->c, XCB_PICT_STANDARD_ARGB_32);
+	auto inner2 = new_inner(base, inner->width, inner->height, visual, 32);
 	if (!inner2) {
 		return false;
 	}


### PR DESCRIPTION
When using `frame-opacity != 1` with the experimental xrender backend the frame does not become transparent if the window has a 24-bit visual (see https://github.com/yshui/picom/issues/342#issuecomment-602266312).

Therefore, force a 32-bit ARGB visual when cloning pixmaps for `IMAGE_OP_APPLY_ALPHA` in the xrender backend.

fixes: #342