### PR TITLE
Fix incorrect frame region in new backends

### DIFF
--- a/src/event.c
+++ b/src/event.c
@@ -506,7 +506,7 @@ static inline void ev_property_notify(session_t *ps, xcb_property_notify_event_t
 	}
 
 	// If frame extents property changes
-	if (ps->o.frame_opacity > 0 && ev->atom == ps->atoms->a_NET_FRAME_EXTENTS) {
+	if (ev->atom == ps->atoms->a_NET_FRAME_EXTENTS) {
 		auto w = find_toplevel(ps, ev->window);
 		if (w) {
 			win_set_property_stale(w, ev->atom);

--- a/src/win.c
+++ b/src/win.c
@@ -231,8 +231,8 @@ void win_get_region_noframe_local(const struct managed_win *w, region_t *res) {
 
 	int x = extents.left;
 	int y = extents.top;
-	int width = max2(w->g.width - (extents.left + extents.right), 0);
-	int height = max2(w->g.height - (extents.top + extents.bottom), 0);
+	int width = max2(w->widthb - (extents.left + extents.right), 0);
+	int height = max2(w->heightb - (extents.top + extents.bottom), 0);
 
 	pixman_region32_fini(res);
 	if (width > 0 && height > 0) {
@@ -246,8 +246,9 @@ gen_without_corners(win_get_region_noframe_local);
 
 void win_get_region_frame_local(const struct managed_win *w, region_t *res) {
 	const margin_t extents = win_calc_frame_extents(w);
-	auto outer_width = extents.left + extents.right + w->g.width;
-	auto outer_height = extents.top + extents.bottom + w->g.height;
+	auto outer_width = w->widthb;
+	auto outer_height = w->heightb;
+
 	pixman_region32_fini(res);
 	pixman_region32_init_rects(
 	    res,


### PR DESCRIPTION
Fix incorrect calculation of window frame region (based on `_NET_FRAME_EXTENTS`) that caused the frame-opacity to be applied only to the top and left frame borders. Opaque windows with blurred transparent frames, would show a blurred outline on the bottom and right.

As mentioned in https://github.com/yshui/picom/commit/fb3305fb9bf7801f0b8608cd92f90d8b548688a8, the window geometry does not include the border width. However, `_NET_FRAME_EXTENTS` seem to include the border width.
So to correctly get the frame regions we subtract the reported frame extents from our window *including* the border width — conveniently already available in `widthb` and `heightb` (compare [frame rendering logic](https://github.com/yshui/picom/blob/5388ba0946bb325b343e04c4dfc66ca05d4d1466/src/render.c#L477-L538) in legacy backend)

Also, don't skip updates to the frame extents when frame-opacity is 0. Some users might [want to use that](https://github.com/yshui/picom/issues/506).

Fixes: https://github.com/yshui/picom/issues/413 https://github.com/yshui/picom/issues/590

I could test the behaviour now being equivalent to the legacy backend in xfce, mate and awesomewm.