### PR TITLE
Use default `detect-client-leader` in sample conf

### DIFF
--- a/picom.sample.conf
+++ b/picom.sample.conf
@@ -276,7 +276,6 @@ detect-transient = true;
 # detect-transient is enabled, too.
 #
 # detect-client-leader = false
-detect-client-leader = true;
 
 # Resize damaged region by a specific number of pixels.
 # A positive value enlarges it while a negative one shrinks it.


### PR DESCRIPTION
See https://github.com/yshui/picom/issues/534

This got me, for whatever reason that issue isn't prioritized very highly by google so it took a while to figure out why this was happening (IE I had to start by seeing if there was an issue in I3 + XFCE, then narrow it down to see if there was an issue in EWMH, then finally realized there was an issue here)

Leaving it as `false` in the sample conf seems to make sense as it matches what most WM's consider `active` and it's such a noticeable setting.

Alternatively, we could just add documentation of this setting to the README to make it more discoverable while leaving the sample conf as is :shrug: 