### PR TITLE
added native optimization compiler flags

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -47,7 +47,10 @@ if get_option('modularize')
 	                     language: 'c')
 endif
 
+add_global_arguments('-O3', language: 'c')
 add_global_arguments('-D_GNU_SOURCE', language: 'c')
+add_global_arguments('-march=native', language: 'c')
+add_global_arguments('-mtune=native', language: 'c')
 
 if cc.has_header('stdc-predef.h')
 	add_global_arguments('-DHAS_STDC_PREDEF_H', language: 'c')


### PR DESCRIPTION
in my case building with `-O3 -march=native -mtune=native` gave me a 40% performance boost (not sure if it was due to flags or due to some new commits). Since most people will be building picom it for their personal use, it makes sense to leverage full potential of their CPUs.