### PR TITLE
allow dots (.) in condition targets

### DIFF
--- a/src/c2.c
+++ b/src/c2.c
@@ -579,8 +579,8 @@ static int c2_parse_target(const char *pattern, int offset, c2_ptr_t *presult) {
 
 	// Copy target name out
 	int tgtlen = 0;
-	for (; pattern[offset] &&
-	       (isalnum((unsigned char)pattern[offset]) || '_' == pattern[offset]);
+	for (; pattern[offset] && (isalnum((unsigned char)pattern[offset]) ||
+	                           '_' == pattern[offset] || '.' == pattern[offset]);
 	     ++offset) {
 		++tgtlen;
 	}


### PR DESCRIPTION
<!-- Please enable "Allow edits from maintainers" so we can make necessary changes to your PR -->
Awesome window manager uses properties that have dots (`.`) in their name, like `awful.client.property.floating(CARDINAL) = 1`. This caused error like `Pattern "awful.client.property.floating@:c = 1" pos 5: Target type cannot be determined.` So why not allow it in target syntax of conditions.

I needed this myself, so I just made a quick edit and did not have time to dive too deep into this project.