### PR TITLE
Fix the DBus introspetion support.

### DIFF
--- a/src/dbus.c
+++ b/src/dbus.c
@@ -709,7 +709,21 @@ static bool cdbus_msg_get_arg(DBusMessage *msg, int count, const int type, void 
 		}
 	}
 
-	if (type != dbus_message_iter_get_arg_type(&iter)) {
+    // Handle auto-generated bindings based on the introspection XML.
+    if (dbus_message_iter_get_arg_type(&iter) == DBUS_TYPE_VARIANT) {
+        DBusMessageIter sub = {};
+        dbus_message_iter_recurse(&iter, &sub);
+
+        if (dbus_message_iter_get_arg_type(&sub) != type) {
+            log_error("Argument has incorrect type.");
+            return false;
+        }
+
+        dbus_message_iter_get_basic(&sub, pdest);
+
+        return true;
+
+    } else if (type != dbus_message_iter_get_arg_type(&iter)) {
 		log_error("Argument has incorrect type.");
 		return false;
 	}
@@ -1206,6 +1220,26 @@ static bool cdbus_process_introspect(session_t *ps, DBusMessage *msg) {
 	    "    </signal>\n"
 	    "    <method name='reset' />\n"
 	    "    <method name='repaint' />\n"
+	    "    <method name='list_win' />\n"
+	    "    <method name='win_get'>\n"
+	    "      <arg name='wid' type='" CDBUS_TYPE_WINDOW_STR "'/>\n"
+	    "      <arg name='target' type='" DBUS_TYPE_STRING_AS_STRING "'/>\n"
+	    "    </method>\n"
+	    "    <method name='win_set'>\n"
+	    "      <arg name='wid' type='" CDBUS_TYPE_WINDOW_STR "'/>\n"
+	    "      <arg name='target' type='" DBUS_TYPE_STRING_AS_STRING "'/>\n"
+	    "      <arg name='value' type='" DBUS_TYPE_VARIANT_AS_STRING "'/>\n"
+	    "    </method>\n"
+	    "    <method name='find_win'>\n"
+	    "      <arg name='target' type='" DBUS_TYPE_STRING_AS_STRING "'/>\n"
+	    "    </method>\n"
+	    "    <method name='opts_get'>\n"
+	    "      <arg name='target' type='" DBUS_TYPE_STRING_AS_STRING "'/>\n"
+	    "    </method>\n"
+	    "    <method name='opts_set'>\n"
+	    "      <arg name='target' type='" DBUS_TYPE_STRING_AS_STRING "'/>\n"
+	    "      <arg name='value' type='" DBUS_TYPE_VARIANT_AS_STRING "'/>\n"
+	    "    </method>\n"
 	    "  </interface>\n"
 	    "</node>\n";
 


### PR DESCRIPTION
### Why

When either using tools like `d-feet` or auto-generatied bindings from the introspection data, most methods were not exposed. The commit also add support for the GVariant datatype in the property setter. This allows auto-generated bindings to work (otherwise it would have to manually edit them after the fact).

### Test

Using `d-feet`, I call "win_set" `41943049, "invert_color_force", GLib.Variant('u',1)` and then "win_get" `41943049, "invert_color_force"` and the value is the same. But I must say the window is **not** getting inverted. However, that doesn't seem related to the patch itself.

Before this patch, those methods were not listed in the GUI.

### What's next

Can a person more knowledgeable with the source describe the pitfall and foot-guns in my way if I want to add the ability to pass a `glsl` shader over dbus? Can it be done per window id or does it has to be global?