### PR TITLE
Fix segfault on 32 bit architectures when using debug logging

### DIFF
--- a/src/backend/backend.c
+++ b/src/backend/backend.c
@@ -44,7 +44,7 @@ region_t get_damage(session_t *ps, bool all_damage) {
 	} else {
 		for (int i = 0; i < buffer_age; i++) {
 			auto curr = ((ps->damage - ps->damage_ring) + i) % ps->ndamage;
-			log_trace("damage index: %d, damage ring offset: %ld", i, curr);
+			log_trace("damage index: %d, damage ring offset: %td", i, curr);
 			dump_region(&ps->damage_ring[curr]);
 			pixman_region32_union(&region, &region, &ps->damage_ring[curr]);
 		}

--- a/src/backend/backend_common.c
+++ b/src/backend/backend_common.c
@@ -92,7 +92,7 @@ make_shadow(xcb_connection_t *c, const conv *kernel, double opacity, int width, 
 	}
 
 	unsigned char *data = ximage->data;
-	long sstride = ximage->stride;
+	long long sstride = ximage->stride;
 
 	// If the window body is smaller than the kernel, we do convolution directly
 	if (width < r * 2 && height < r * 2) {

--- a/src/c2.c
+++ b/src/c2.c
@@ -1324,13 +1324,13 @@ static inline void c2_match_once_leaf(session_t *ps, const struct managed_win *w
 	switch (pleaf->ptntype) {
 	// Deal with integer patterns
 	case C2_L_PTINT: {
-		long *targets = NULL;
-		long *targets_free = NULL;
+		long long *targets = NULL;
+		long long *targets_free = NULL;
 		size_t ntargets = 0;
 
 		// Get the value
 		// A predefined target
-		long predef_target = 0;
+		long long predef_target = 0;
 		if (pleaf->predef != C2_L_PUNDEFINED) {
 			*perr = false;
 			switch (pleaf->predef) {
@@ -1379,7 +1379,7 @@ static inline void c2_match_once_leaf(session_t *ps, const struct managed_win *w
 
 			ntargets = (pleaf->index < 0 ? prop.nitems : min2(prop.nitems, 1));
 			if (ntargets > 0) {
-				targets = targets_free = ccalloc(ntargets, long);
+				targets = targets_free = ccalloc(ntargets, long long);
 				*perr = false;
 				for (size_t i = 0; i < ntargets; ++i) {
 					targets[i] = winprop_get_int(prop, i);
@@ -1395,7 +1395,7 @@ static inline void c2_match_once_leaf(session_t *ps, const struct managed_win *w
 		// Do comparison
 		bool res = false;
 		for (size_t i = 0; i < ntargets; ++i) {
-			long tgt = targets[i];
+			long long tgt = targets[i];
 			switch (pleaf->op) {
 			case C2_L_OEXISTS:
 				res = (pleaf->predef != C2_L_PUNDEFINED ? tgt : true);

--- a/src/common.h
+++ b/src/common.h
@@ -245,7 +245,7 @@ typedef struct session {
 	/// Pre-generated alpha pictures.
 	xcb_render_picture_t *alpha_picts;
 	/// Time of last fading. In milliseconds.
-	long fade_time;
+	long long fade_time;
 	/// Head pointer of the error ignore linked list.
 	ignore_t *ignore_head;
 	/// Pointer to the <code>next</code> member of tail element of the error

--- a/src/picom.c
+++ b/src/picom.c
@@ -243,7 +243,7 @@ static double fade_timeout(session_t *ps) {
  * @param steps steps of fading
  * @return whether we are still in fading mode
  */
-static bool run_fade(session_t *ps, struct managed_win **_w, long steps) {
+static bool run_fade(session_t *ps, struct managed_win **_w, long long steps) {
 	auto w = *_w;
 	if (w->state == WSTATE_MAPPED || w->state == WSTATE_UNMAPPED) {
 		// We are not fading
@@ -635,7 +635,7 @@ static struct managed_win *paint_preprocess(session_t *ps, bool *fade_running) {
 	*fade_running = false;
 
 	// Fading step calculation
-	long steps = 0L;
+	long long steps = 0L;
 	auto now = get_time_ms();
 	if (ps->fade_time) {
 		assert(now >= ps->fade_time);

--- a/src/win.c
+++ b/src/win.c
@@ -958,7 +958,7 @@ static void win_determine_shadow(session_t *ps, struct managed_win *w) {
  * things.
  */
 void win_update_prop_shadow(session_t *ps, struct managed_win *w) {
-	long attr_shadow_old = w->prop_shadow;
+	long long attr_shadow_old = w->prop_shadow;
 
 	win_update_prop_shadow_raw(ps, w);
 

--- a/src/win.h
+++ b/src/win.h
@@ -139,7 +139,7 @@ struct managed_win {
 	/// bitmap for properties which needs to be updated
 	uint64_t *stale_props;
 	/// number of uint64_ts that has been allocated for stale_props
-	uint64_t stale_props_capacity;
+	size_t stale_props_capacity;
 
 	/// Bounding shape of the window. In local coordinates.
 	/// See above about coordinate systems.
@@ -253,7 +253,7 @@ struct managed_win {
 	paint_t shadow_paint;
 	/// The value of _COMPTON_SHADOW attribute of the window. Below 0 for
 	/// none.
-	long prop_shadow;
+	long long prop_shadow;
 	/// Do not paint shadow over this window.
 	bool clip_shadow_above;
 

--- a/tests/testcases/basic.py
+++ b/tests/testcases/basic.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import xcffib.xproto as xproto
 import xcffib

--- a/tests/testcases/clear_shadow_unredirected.py
+++ b/tests/testcases/clear_shadow_unredirected.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import xcffib.xproto as xproto
 import xcffib

--- a/tests/testcases/issue239.py
+++ b/tests/testcases/issue239.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import xcffib.xproto as xproto
 import xcffib

--- a/tests/testcases/issue239_2.py
+++ b/tests/testcases/issue239_2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import xcffib.xproto as xproto
 import xcffib

--- a/tests/testcases/issue239_3.py
+++ b/tests/testcases/issue239_3.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import xcffib.xproto as xproto
 import xcffib

--- a/tests/testcases/issue239_3_norefresh.py
+++ b/tests/testcases/issue239_3_norefresh.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import xcffib.xproto as xproto
 import xcffib

--- a/tests/testcases/issue314.py
+++ b/tests/testcases/issue314.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import xcffib.xproto as xproto
 import xcffib

--- a/tests/testcases/issue314_2.py
+++ b/tests/testcases/issue314_2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import xcffib.xproto as xproto
 import xcffib

--- a/tests/testcases/issue314_3.py
+++ b/tests/testcases/issue314_3.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import xcffib.xproto as xproto
 import xcffib

--- a/tests/testcases/issue357.py
+++ b/tests/testcases/issue357.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import xcffib.xproto as xproto
 import xcffib

--- a/tests/testcases/issue394.py
+++ b/tests/testcases/issue394.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import xcffib.xproto as xproto
 import xcffib

--- a/tests/testcases/issue465.py
+++ b/tests/testcases/issue465.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import xcffib.xproto as xproto
 import xcffib

--- a/tests/testcases/issue525.py
+++ b/tests/testcases/issue525.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import xcffib.xproto as xproto
 import xcffib

--- a/tests/testcases/redirect_when_unmapped_window_has_shadow.py
+++ b/tests/testcases/redirect_when_unmapped_window_has_shadow.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import xcffib.xproto as xproto
 import xcffib


### PR DESCRIPTION
When running the tests on 32 bit architectures, `picom` was segfaulting because (I think) of using `%ld` in printf-style format strings when passing 64 bit numbers. I used `PRIu64` for these cases and fixed the other warnings that showed up when compiling on 32 bits.
FYI `long long` is 64 bits in size on both 32 bit and 64 bit architectures: https://logncomplexity.wordpress.com/2016/01/20/integer-sizes-in-c-on-32-bit-and-64-bit-linux/.

I also changed all the `tests/testcases/*` files to use `python3` in the shebang since all of the python files are compatible with python 3. (The command I used to do that is: `find tests/testcases/ -type f -exec sed -i 's|env python$|env python3|g' {} \;`)