### PR TITLE
Detect and handle GPU reset

### DIFF
--- a/src/backend/backend.h
+++ b/src/backend/backend.h
@@ -32,6 +32,15 @@ typedef struct backend_base {
 
 typedef void (*backend_ready_callback_t)(void *);
 
+// This mimics OpenGL's ARB_robustness extension, which enables detection of GPU context
+// resets.
+// See: https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_robustness.txt, section
+// 2.6 "Graphics Reset Recovery".
+enum device_status {
+	DEVICE_STATUS_NORMAL,
+	DEVICE_STATUS_RESETTING,
+};
+
 // When image properties are actually applied to the image, they are applied in a
 // particular order:
 //
@@ -273,6 +282,8 @@ struct backend_operations {
 	enum driver (*detect_driver)(backend_t *backend_data);
 
 	void (*diagnostics)(backend_t *backend_data);
+
+	enum device_status (*device_status)(backend_t *backend_data);
 };
 
 extern struct backend_operations *backend_list[];

--- a/src/backend/gl/gl_common.c
+++ b/src/backend/gl/gl_common.c
@@ -1694,6 +1694,7 @@ bool gl_init(struct gl_data *gd, session_t *ps) {
 	} else {
 		gd->is_nvidia = false;
 	}
+	gd->has_robustness = gl_has_extension("GL_ARB_robustness");
 
 	return true;
 }
@@ -1907,4 +1908,16 @@ bool gl_image_op(backend_t *base, enum image_operations op, void *image_data,
 	}
 
 	return true;
+}
+
+enum device_status gl_device_status(backend_t *base) {
+	auto gd = (struct gl_data *)base;
+	if (!gd->has_robustness) {
+		return DEVICE_STATUS_NORMAL;
+	}
+	if (glGetGraphicsResetStatusARB() == GL_NO_ERROR) {
+		return DEVICE_STATUS_NORMAL;
+	} else {
+		return DEVICE_STATUS_RESETTING;
+	}
 }

--- a/src/backend/gl/gl_common.h
+++ b/src/backend/gl/gl_common.h
@@ -75,6 +75,8 @@ struct gl_data {
 	backend_t base;
 	// If we are using proprietary NVIDIA driver
 	bool is_nvidia;
+	// If ARB_robustness extension is present
+	bool has_robustness;
 	// Height and width of the root window
 	int height, width;
 	gl_win_shader_t win_shader;
@@ -132,6 +134,7 @@ void gl_fill(backend_t *base, struct color, const region_t *clip);
 
 void gl_present(backend_t *base, const region_t *);
 bool gl_read_pixel(backend_t *base, void *image_data, int x, int y, struct color *output);
+enum device_status gl_device_status(backend_t *base);
 
 static inline void gl_delete_texture(GLuint texture) {
 	glDeleteTextures(1, &texture);

--- a/src/backend/gl/glx.h
+++ b/src/backend/gl/glx.h
@@ -55,6 +55,7 @@ struct glxext_info {
 	bool has_GLX_ARB_create_context;
 	bool has_GLX_EXT_buffer_age;
 	bool has_GLX_MESA_query_renderer;
+	bool has_GLX_ARB_create_context_robustness;
 };
 
 extern struct glxext_info glxext;


### PR DESCRIPTION
Use GL_ARB_robustness extension to detect GPU reset, and reset picom.

This is only marginally helpful. Yes, with this picom indeed regain normal function after GPU resets, but since X doesn't handle reset properly, all the windows have garbled content. Maybe in the future we can display some kind of warnings/instructions to the user if a reset happens.