### PR TITLE
Fix shadow for rounded windows (#783)

### DIFF
--- a/src/backend/backend.c
+++ b/src/backend/backend.c
@@ -304,7 +304,13 @@ void paint_all_new(session_t *ps, struct managed_win *t, bool ignore_damage) {
 			auto reg_shadow = win_extents_by_val(w);
 			pixman_region32_intersect(&reg_shadow, &reg_shadow, &reg_paint);
 			if (!ps->o.wintype_option[w->window_type].full_shadow) {
-				pixman_region32_subtract(&reg_shadow, &reg_shadow, &reg_bound);
+				if (w->corner_radius > 0) {
+					auto reg_bound_no_corner = win_get_bounding_shape_global_without_corners_by_val(w);
+					pixman_region32_subtract(&reg_shadow, &reg_shadow, &reg_bound_no_corner);
+					pixman_region32_fini(&reg_bound_no_corner);
+				} else {
+					pixman_region32_subtract(&reg_shadow, &reg_shadow, &reg_bound);
+				}
 			}
 
 			// Mask out the region we don't want shadow on


### PR DESCRIPTION
Hi,

Thank you a lot for Picom and your work on merging what ibhagwan has done mainstream small bit by small bit. This PR fixes #783 which I can reproduce on my setup. This is because we don't exclude the rounded corners when we draw the shadows. With this fix, I don't have any more issue locally.

I inspired myself from this commit on a fork : https://github.com/s0nny7/picom/commit/d74c099083487783af7254cb55780ffb20100e53

Happy to add any documentation, test or wathever you need me to :)