### PR TITLE
Delay (re-)creation of the mask image, uncouple from shadow image

### DIFF
--- a/src/backend/backend.c
+++ b/src/backend/backend.c
@@ -211,10 +211,6 @@ void paint_all_new(session_t *ps, struct managed_win *t, bool ignore_damage) {
 		auto reg_bound_no_corner =
 		    win_get_bounding_shape_global_without_corners_by_val(w);
 
-		if (!w->mask_image && (w->bounding_shaped || w->corner_radius != 0)) {
-			win_bind_mask(ps->backend_data, w);
-		}
-
 		// The clip region for the current window, in global/target coordinates
 		// reg_paint_in_bound \in reg_paint
 		region_t reg_paint_in_bound;

--- a/src/win_defs.h
+++ b/src/win_defs.h
@@ -94,9 +94,14 @@ enum win_flags {
 	WIN_FLAGS_POSITION_STALE = 512,
 	/// need better name for this, is set when some aspects of the window changed
 	WIN_FLAGS_FACTOR_CHANGED = 1024,
+	/// mask is out of date, will be updated in win_process_flags
+	WIN_FLAGS_MASK_STALE = 2048,
+	/// mask has not been generated
+	WIN_FLAGS_MASK_NONE = 4096,
 };
 
 static const uint64_t WIN_FLAGS_IMAGES_STALE =
-    WIN_FLAGS_PIXMAP_STALE | WIN_FLAGS_SHADOW_STALE;
+    WIN_FLAGS_PIXMAP_STALE | WIN_FLAGS_MASK_STALE | WIN_FLAGS_SHADOW_STALE;
 
-#define WIN_FLAGS_IMAGES_NONE (WIN_FLAGS_PIXMAP_NONE | WIN_FLAGS_SHADOW_NONE)
+#define WIN_FLAGS_IMAGES_NONE                                                            \
+	(WIN_FLAGS_PIXMAP_NONE | WIN_FLAGS_MASK_NONE | WIN_FLAGS_SHADOW_NONE)


### PR DESCRIPTION
Move the creation / binding of mask images into the critical section. Delay binding and release with `WINDOW_FLAGS_MASK_STALE` (part of `WINDOW_FLAGS_IMAGES_STALE`) analog to the handling of shadow images.

No longer bind the mask image when creating the shadow as the mask might not have changed and therefore not been released before. (Previously, the mask might have been already created in `paint_all_new`)

Bind the mask before binding the shadow, so we can use it for shadow creating. Only bind when corner-radius is set or the window is shaped.

should fix: https://github.com/yshui/picom/issues/1029

---

This fixes the assertion failure in `win_bind_mask()` to protect against leaking a mask image.

- When a window is created without shadow but rounded corners, `paint_all_new()` will create and bind a (new) mask image.
- Once the window receives shadow, a new shadow image is created.
- If the window has rounded corners, first a (new) mask image is bound, and then the shadow created and bound based on that mask (if supported by the backend).
- This triggers the assertion, since the mask image is already bound (in `paint_all_new()`)

Can be reproduced with:
```
$ picom --config /dev/null --backend glx --shadow --shadow-exclude focused --corner-radius 15
```

Currently, no automated test can be written for this case, because the dummy backend does not support creating the shadow image from a mask image and therefore will never go through the affected code path.