### PR TITLE
Add noise to blur shaders

### DIFF
--- a/include/picom/backend.h
+++ b/include/picom/backend.h
@@ -54,7 +54,10 @@ enum shader_attributes {
 	SHADER_ATTRIBUTE_ANIMATED = 1,
 };
 
-struct blur_args {};
+struct blur_args {
+	int noise_radius;
+	double noise_scale;
+};
 
 struct gaussian_blur_args {
 	struct blur_args base;

--- a/include/picom/backend.h
+++ b/include/picom/backend.h
@@ -54,21 +54,27 @@ enum shader_attributes {
 	SHADER_ATTRIBUTE_ANIMATED = 1,
 };
 
+struct blur_args {};
+
 struct gaussian_blur_args {
+	struct blur_args base;
 	int size;
 	double deviation;
 };
 
 struct box_blur_args {
+	struct blur_args base;
 	int size;
 };
 
 struct kernel_blur_args {
+	struct blur_args base;
 	struct conv **kernels;
 	int kernel_count;
 };
 
 struct dual_kawase_blur_args {
+	struct blur_args base;
 	int size;
 	int strength;
 };
@@ -433,7 +439,7 @@ struct backend_operations {
 	/// Create a blur context that can be used to call `blur` for images with a
 	/// specific format.
 	void *(*create_blur_context)(backend_t *base, enum blur_method,
-	                             enum backend_image_format format, void *args);
+	                             enum backend_image_format format, struct blur_args *args);
 	/// Destroy a blur context
 	void (*destroy_blur_context)(backend_t *base, void *ctx);
 	/// Get how many pixels outside of the blur area is needed for blur

--- a/man/picom.1.adoc
+++ b/man/picom.1.adoc
@@ -178,6 +178,9 @@ OPTIONS
 *--blur-method*, *--blur-size*, *--blur-deviation*, *--blur-strength*::
 	Parameters for background blurring, see the xref:_blur[*BLUR*] section for more information.
 
+*--blur-noise-radius*, *--blur-noise-scale*::
+	Parameters for blur noise. See the xref:_blur[*BLUR*] section for more information.
+
 *--blur-background*::
 	Blur background of semi-transparent / ARGB windows. Bad in performance, with driver-dependent behavior. The name of the switch may change without prior notifications.
 
@@ -916,6 +919,14 @@ Available options of the _blur_ section are: ::
 
   *kernel*:::
     A string. The kernel to use for the _kernel_ blur method, specified in the same format as the *--blur-kern* option. Corresponds to the *--blur-kern* command line option.
+
+If blur is enabled, noise can be configured with the following options: ::
+
+  *noise-radius*:::
+  An integer. The maximum displacement of background pixels when applying noise. Corresponds to the *--blur-noise-radius* command line option. If set to zero, noise is disabled (default: 0).
+
+  *noise-scale*:::
+  A floating point number. The size of noise features. Corresponds to the *--blur-noise-scale* command line option. If negative or zero, noise is disabled (default: 0.005).
 
 SIGNALS
 -------

--- a/src/backend/backend_common.c
+++ b/src/backend/backend_common.c
@@ -252,11 +252,14 @@ generate_gaussian_blur_kernel(struct gaussian_blur_args *args, int *kernel_count
 
 /// Generate blur kernels for gaussian and box blur methods. Generated kernel is not
 /// normalized, and the center element will always be 1.
-struct conv **generate_blur_kernel(enum blur_method method, void *args, int *kernel_count) {
+struct conv **
+generate_blur_kernel(enum blur_method method, struct blur_args *args, int *kernel_count) {
 	switch (method) {
-	case BLUR_METHOD_BOX: return generate_box_blur_kernel(args, kernel_count);
+	case BLUR_METHOD_BOX:
+		return generate_box_blur_kernel((struct box_blur_args *)args, kernel_count);
 	case BLUR_METHOD_GAUSSIAN:
-		return generate_gaussian_blur_kernel(args, kernel_count);
+		return generate_gaussian_blur_kernel((struct gaussian_blur_args *)args,
+		                                     kernel_count);
 	default: break;
 	}
 	return NULL;
@@ -264,8 +267,8 @@ struct conv **generate_blur_kernel(enum blur_method method, void *args, int *ker
 
 /// Generate kernel parameters for dual-kawase blur method. Falls back on approximating
 /// standard gauss radius if strength is zero or below.
-struct dual_kawase_params *generate_dual_kawase_params(void *args) {
-	struct dual_kawase_blur_args *blur_args = args;
+struct dual_kawase_params *generate_dual_kawase_params(struct blur_args *args) {
+	auto blur_args = (struct dual_kawase_blur_args *)args;
 	static const struct {
 		int iterations;        /// Number of down- and upsample iterations
 		float offset;          /// Sample offset in half-pixels

--- a/src/backend/backend_common.h
+++ b/src/backend/backend_common.h
@@ -15,6 +15,7 @@ struct conv;
 struct backend_base;
 struct backend_operations;
 struct x_connection;
+struct blur_args;
 
 struct dual_kawase_params {
 	/// Number of downsample passes
@@ -33,7 +34,8 @@ solid_picture(struct x_connection *, bool argb, double a, double r, double g, do
 
 void init_backend_base(struct backend_base *base, session_t *ps);
 
-struct conv **generate_blur_kernel(enum blur_method method, void *args, int *kernel_count);
-struct dual_kawase_params *generate_dual_kawase_params(void *args);
+struct conv **
+generate_blur_kernel(enum blur_method method, struct blur_args *args, int *kernel_count);
+struct dual_kawase_params *generate_dual_kawase_params(struct blur_args *args);
 
 uint32_t backend_no_quirks(struct backend_base *base attr_unused);

--- a/src/backend/dummy/dummy.c
+++ b/src/backend/dummy/dummy.c
@@ -179,7 +179,7 @@ image_handle dummy_back_buffer(struct backend_base *base) {
 void *dummy_create_blur_context(struct backend_base *base attr_unused,
                                 enum blur_method method attr_unused,
                                 enum backend_image_format format attr_unused,
-                                void *args attr_unused) {
+                                struct blur_args *args attr_unused) {
 	static int dummy_context;
 	return &dummy_context;
 }

--- a/src/backend/gl/blur.c
+++ b/src/backend/gl/blur.c
@@ -846,7 +846,7 @@ out:
 }
 
 void *gl_create_blur_context(backend_t *base, enum blur_method method,
-                             enum backend_image_format format, void *args) {
+                             enum backend_image_format format, struct blur_args *args) {
 	bool success;
 	auto gd = (struct gl_data *)base;
 

--- a/src/backend/gl/blur.c
+++ b/src/backend/gl/blur.c
@@ -37,6 +37,9 @@ struct gl_blur_context {
 	/// How much do we need to resize the damaged region for blurring.
 	int resize_width, resize_height;
 
+	int noise_radius;
+	float noise_scale;
+
 	int npasses;
 
 	enum backend_image_format format;
@@ -114,6 +117,8 @@ gl_kernel_blur(double opacity, struct gl_blur_context *bctx,
 			}
 
 			glUniform1f(UNIFORM_OPACITY_LOC, 1.0F);
+			glUniform1i(UNIFORM_BLUR_NOISE_RADIUS_LOC, 0);
+			glUniform1f(UNIFORM_BLUR_NOISE_SCALE_LOC, 0.0F);
 		} else {
 			// last pass, draw directly into the back buffer, with origin
 			// regions. And apply mask if requested
@@ -135,6 +140,8 @@ gl_kernel_blur(double opacity, struct gl_blur_context *bctx,
 			glBindFramebuffer(GL_FRAMEBUFFER, target_fbo);
 
 			glUniform1f(UNIFORM_OPACITY_LOC, (float)opacity);
+			glUniform1i(UNIFORM_BLUR_NOISE_RADIUS_LOC, bctx->noise_radius);
+			glUniform1f(UNIFORM_BLUR_NOISE_SCALE_LOC, bctx->noise_scale);
 			glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
 		}
 
@@ -220,6 +227,8 @@ bool gl_dual_kawase_blur(double opacity, struct gl_blur_context *bctx,
 	glUniform1f(UNIFORM_MASK_CORNER_RADIUS_LOC, 0.0F);
 	glUniform2f(UNIFORM_MASK_SCALE_LOC, 1.0F, 1.0F);
 	glUniform1f(UNIFORM_OPACITY_LOC, 1.0F);
+	glUniform1i(UNIFORM_BLUR_NOISE_RADIUS_LOC, 0);
+	glUniform1f(UNIFORM_BLUR_NOISE_SCALE_LOC, 0.0F);
 
 	for (int i = iterations - 1; i >= 0; --i) {
 		// Scale output width / height back by two in each iteration
@@ -263,6 +272,8 @@ bool gl_dual_kawase_blur(double opacity, struct gl_blur_context *bctx,
 			glBindFramebuffer(GL_DRAW_FRAMEBUFFER, target_fbo);
 
 			glUniform1f(UNIFORM_OPACITY_LOC, (GLfloat)opacity);
+			glUniform1i(UNIFORM_BLUR_NOISE_RADIUS_LOC, bctx->noise_radius);
+			glUniform1f(UNIFORM_BLUR_NOISE_SCALE_LOC, bctx->noise_scale);
 			glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
 		}
 
@@ -536,11 +547,16 @@ bool gl_create_kernel_blur_context(void *blur_context, GLfloat *projection,
 		uniform vec2 pixel_norm;
 		layout(location = UNIFORM_OPACITY_LOC)
 		uniform float opacity;
+		layout(location = UNIFORM_BLUR_NOISE_RADIUS_LOC)
+		uniform int noise_radius;
+		layout(location = UNIFORM_BLUR_NOISE_SCALE_LOC)
+		uniform float noise_scale;
 		in vec2 texcoord;
 		out vec4 out_color;
 		float mask_factor();
+		vec2 perturb(vec2, float, float);
 		void main() {
-			vec2 uv = texcoord * pixel_norm;
+			vec2 uv = perturb(texcoord, noise_radius, noise_scale) * pixel_norm;
 			vec4 sum = vec4(0.0, 0.0, 0.0, 0.0);
 			%s //body of the convolution
 			out_color = sum / float(%.7g) * opacity * mask_factor();
@@ -634,7 +650,7 @@ bool gl_create_kernel_blur_context(void *blur_context, GLfloat *projection,
 		// Build program
 		pass->prog = gl_create_program_from_strv(
 		    (const char *[]){vertex_shader, NULL},
-		    (const char *[]){shader_str, scaled_masking_glsl, NULL});
+		    (const char *[]){shader_str, scaled_masking_glsl, perturb_glsl, NULL});
 		free(shader_str);
 		if (!pass->prog) {
 			log_error("Failed to create GLSL program.");
@@ -658,7 +674,8 @@ bool gl_create_kernel_blur_context(void *blur_context, GLfloat *projection,
 		auto pass = &ctx->blur_shader[1];
 		pass->prog = gl_create_program_from_strv(
 		    (const char *[]){vertex_shader, NULL},
-		    (const char *[]){blend_with_mask_frag, scaled_masking_glsl, NULL});
+		    (const char *[]){blend_with_mask_frag, scaled_masking_glsl,
+		                     perturb_glsl, NULL});
 
 		// Setup projection matrix
 		glUseProgram(pass->prog);
@@ -775,12 +792,17 @@ bool gl_create_dual_kawase_blur_context(void *blur_context, GLfloat *projection,
 			uniform vec2 pixel_norm;
 			layout(location = UNIFORM_OPACITY_LOC)
 			uniform float opacity;
+			layout(location = UNIFORM_BLUR_NOISE_RADIUS_LOC)
+			uniform int noise_radius;
+			layout(location = UNIFORM_BLUR_NOISE_SCALE_LOC)
+			uniform float noise_scale;
 			in vec2 texcoord;
 			out vec4 out_color;
 			float mask_factor();
+			vec2 perturb(vec2, float, float);
 			void main() {
 				vec2 offset = %.7g * pixel_norm;
-				vec2 uv = texcoord * pixel_norm / (2 * scale);
+				vec2 uv = perturb(texcoord, noise_radius, noise_scale) * pixel_norm / (2 * scale);
 				vec4 sum = texture2D(tex_src, uv + vec2(-1.0, 0.0) * offset);
 				sum += texture2D(tex_src, uv + vec2(-0.5, 0.5) * offset) * 2.0;
 				sum += texture2D(tex_src, uv + vec2(0.0, 1.0) * offset);
@@ -806,7 +828,7 @@ bool gl_create_dual_kawase_blur_context(void *blur_context, GLfloat *projection,
 		// Build program
 		up_pass->prog = gl_create_program_from_strv(
 		    (const char *[]){vertex_shader, NULL},
-		    (const char *[]){shader_str, scaled_masking_glsl, NULL});
+		    (const char *[]){shader_str, scaled_masking_glsl, perturb_glsl, NULL});
 		free(shader_str);
 		if (!up_pass->prog) {
 			log_error("Failed to create GLSL program.");
@@ -864,6 +886,12 @@ void *gl_create_blur_context(backend_t *base, enum blur_method method,
 	if (!success || ctx->method == BLUR_METHOD_NONE) {
 		goto out;
 	}
+
+	ctx->noise_radius = args->noise_radius;
+	ctx->noise_scale = (float)args->noise_scale;
+	// Expand the blur region to account for noise samples
+	ctx->resize_width = max2(ctx->resize_width, ctx->noise_radius);
+	ctx->resize_height = max2(ctx->resize_height, ctx->noise_radius);
 
 	// Texture size will be defined by gl_blur
 	ctx->blur_textures = ccalloc(ctx->blur_texture_count, GLuint);

--- a/src/backend/gl/blur.c
+++ b/src/backend/gl/blur.c
@@ -534,7 +534,6 @@ bool gl_create_kernel_blur_context(void *blur_context, GLfloat *projection,
 
 	// clang-format off
 	static const char *FRAG_SHADER_BLUR = GLSL(330,
-		%s\n // other extension pragmas
 		layout(location = UNIFORM_TEX_SRC_LOC)
 		uniform sampler2D tex_src;
 		layout(location = UNIFORM_PIXEL_NORM_LOC)
@@ -557,7 +556,6 @@ bool gl_create_kernel_blur_context(void *blur_context, GLfloat *projection,
 	// clang-format on
 
 	const char *shader_add = FRAG_SHADER_BLUR_ADD;
-	char *extension = strdup("");
 
 	for (int i = 0; i < nkernels; i++) {
 		auto kern = kernels[i];
@@ -628,12 +626,11 @@ bool gl_create_kernel_blur_context(void *blur_context, GLfloat *projection,
 		}
 
 		auto pass = ctx->blur_shader + i;
-		size_t shader_len = strlen(FRAG_SHADER_BLUR) + strlen(extension) +
-		                    strlen(shader_body) + 10 /* sum */ +
-		                    1 /* null terminator */;
+		size_t shader_len = strlen(FRAG_SHADER_BLUR) + strlen(shader_body) +
+		                    10 /* sum */ + 1 /* null terminator */;
 		char *shader_str = ccalloc(shader_len, char);
-		auto real_shader_len = snprintf(shader_str, shader_len, FRAG_SHADER_BLUR,
-		                                extension, shader_body, sum);
+		auto real_shader_len =
+		    snprintf(shader_str, shader_len, FRAG_SHADER_BLUR, shader_body, sum);
 		CHECK(real_shader_len >= 0);
 		CHECK((size_t)real_shader_len < shader_len);
 		free(shader_body);
@@ -688,7 +685,6 @@ out:
 		free(kernels);
 	}
 
-	free(extension);
 	// Restore LC_NUMERIC
 	setlocale(LC_NUMERIC, lc_numeric_old);
 	free(lc_numeric_old);

--- a/src/backend/gl/blur.c
+++ b/src/backend/gl/blur.c
@@ -834,10 +834,6 @@ bool gl_create_dual_kawase_blur_context(void *blur_context, GLfloat *projection,
 out:
 	free(blur_params);
 
-	if (!success) {
-		ctx = NULL;
-	}
-
 	// Restore LC_NUMERIC
 	setlocale(LC_NUMERIC, lc_numeric_old);
 	free(lc_numeric_old);

--- a/src/backend/gl/blur.c
+++ b/src/backend/gl/blur.c
@@ -82,12 +82,8 @@ gl_kernel_blur(double opacity, struct gl_blur_context *bctx,
 		glBindTexture(GL_TEXTURE_2D, src_texture);
 		glBindSampler(0, blur_sampler);
 		glUseProgram(p->prog);
-		if (p->uniform_bitmask & (1 << UNIFORM_PIXEL_NORM_LOC)) {
-			// If the last pass is a trivial blend pass, it will not have
-			// pixel_norm.
-			glUniform2f(UNIFORM_PIXEL_NORM_LOC, 1.0F / (GLfloat)tex_width,
-			            1.0F / (GLfloat)tex_height);
-		}
+		glUniform2f(UNIFORM_PIXEL_NORM_LOC, 1.0F / (GLfloat)tex_width,
+		            1.0F / (GLfloat)tex_height);
 
 		glActiveTexture(GL_TEXTURE1);
 		glBindTexture(GL_TEXTURE_2D, default_mask);
@@ -645,7 +641,6 @@ bool gl_create_kernel_blur_context(void *blur_context, GLfloat *projection,
 			success = false;
 			goto out;
 		}
-		pass->uniform_bitmask = 1 << UNIFORM_PIXEL_NORM_LOC;
 		glBindFragDataLocation(pass->prog, 0, "out_color");
 
 		// Setup projection matrix

--- a/src/backend/gl/gl_common.h
+++ b/src/backend/gl/gl_common.h
@@ -313,4 +313,4 @@ static const GLuint vert_in_texcoord_loc = 1;
 extern const char vertex_shader[], blend_with_mask_frag[], masking_glsl[],
     scaled_masking_glsl[], copy_area_frag[], copy_area_with_dither_frag[], fill_frag[],
     fill_vert[], interpolating_frag[], interpolating_vert[], blit_shader_glsl[],
-    blit_shader_default[], present_vertex_shader[], dither_glsl[];
+    blit_shader_default[], present_vertex_shader[], dither_glsl[], perturb_glsl[];

--- a/src/backend/gl/gl_common.h
+++ b/src/backend/gl/gl_common.h
@@ -173,7 +173,7 @@ image_handle gl_back_buffer(struct backend_base *base);
 uint32_t gl_image_capabilities(backend_t *base, image_handle img);
 bool gl_is_format_supported(backend_t *base, enum backend_image_format format);
 void *gl_create_blur_context(backend_t *base, enum blur_method,
-                             enum backend_image_format format, void *args);
+                             enum backend_image_format format, struct blur_args *args);
 void gl_destroy_blur_context(backend_t *base, void *ctx);
 void gl_get_blur_size(void *blur_context, int *width, int *height);
 

--- a/src/backend/gl/gl_common.h
+++ b/src/backend/gl/gl_common.h
@@ -40,7 +40,9 @@ struct gl_blur_context;
 // Added in backend API 2.0
 #define UNIFORM_TINT_LOC 22
 #define UNIFORM_MASK_SCALE_LOC 23
-#define NUMBER_OF_UNIFORMS (UNIFORM_TINT_LOC + 1)
+#define UNIFORM_BLUR_NOISE_RADIUS_LOC 24
+#define UNIFORM_BLUR_NOISE_SCALE_LOC 25
+#define NUMBER_OF_UNIFORMS (UNIFORM_BLUR_NOISE_SCALE_LOC + 1)
 
 struct gl_shader {
 	GLuint prog;

--- a/src/backend/gl/shaders.c
+++ b/src/backend/gl/shaders.c
@@ -26,12 +26,15 @@ const char copy_area_with_dither_frag[] = GLSL(330,
 const char blend_with_mask_frag[] = GLSL(330,
 	layout(location = UNIFORM_TEX_LOC)
 	uniform sampler2D tex;
+	layout(location = UNIFORM_PIXEL_NORM_LOC)
+	uniform vec2 pixel_norm;
 	layout(location = UNIFORM_OPACITY_LOC)
 	uniform float opacity;
 	in vec2 texcoord;
 	float mask_factor();
 	void main() {
-		gl_FragColor = texelFetch(tex, ivec2(texcoord.xy), 0) * opacity * mask_factor();
+		vec2 uv = texcoord * pixel_norm;
+		gl_FragColor = texture2D(tex, uv) * opacity * mask_factor();
 	}
 );
 

--- a/src/backend/gl/shaders.c
+++ b/src/backend/gl/shaders.c
@@ -30,10 +30,15 @@ const char blend_with_mask_frag[] = GLSL(330,
 	uniform vec2 pixel_norm;
 	layout(location = UNIFORM_OPACITY_LOC)
 	uniform float opacity;
+	layout(location = UNIFORM_BLUR_NOISE_RADIUS_LOC)
+	uniform int noise_radius;
+	layout(location = UNIFORM_BLUR_NOISE_SCALE_LOC)
+	uniform float noise_scale;
 	in vec2 texcoord;
 	float mask_factor();
+	vec2 perturb(vec2, float, float);
 	void main() {
-		vec2 uv = texcoord * pixel_norm;
+		vec2 uv = perturb(texcoord, noise_radius, noise_scale) * pixel_norm;
 		gl_FragColor = texture2D(tex, uv) * opacity * mask_factor();
 	}
 );
@@ -264,6 +269,82 @@ const char dither_glsl[] = GLSL(330,
 		residual = min(residual, vec4(1.0 / 255.0) - residual);
 		vec4 dithered = vec4(greaterThan(residual, vec4(1.0 / 65535.0)));
 		return vec4(c + dithered * bayer(coord) / 255.0);
+	}
+);
+
+const char perturb_glsl[] = GLSL(330,
+	// GLSL 2D Simplex noise function
+	// Copyright (c) 2011 Ashima Arts. All rights reserved.
+	// Distributed under the MIT License. See https://github.com/stegu/webgl-noise
+	vec3 mod289(vec3 x) {
+		return x - floor(x * (1.0 / 289.0)) * 289.0;
+	}
+
+	vec2 mod289(vec2 x) {
+		return x - floor(x * (1.0 / 289.0)) * 289.0;
+	}
+
+	vec3 permute(vec3 x) {
+		return mod289(((x * 34.0) + 10.0) * x);
+	}
+
+	float snoise(vec2 v) {
+		const vec4 C = vec4(0.211324865405187,  // (3.0 - sqrt(3.0)) / 6.0
+		                    0.366025403784439,  // 0.5 * (sqrt(3.0) - 1.0)
+		                   -0.577350269189626,  // -1.0 + 2.0 * C.x
+		                    0.024390243902439); // 1.0 / 41.0
+
+		// First corner
+		vec2 i  = floor(v + dot(v, C.yy));
+		vec2 x0 = v -   i + dot(i, C.xx);
+
+		// Other corners
+		// i1.x = x0.x > x0.y ? 1.0 : 0.0
+		// i1.y = 1.0 - i1.x
+		vec2 i1 = (x0.x > x0.y) ? vec2(1.0, 0.0) : vec2(0.0, 1.0);
+		// x0 = x0 - 0.0 + 0.0 * C.xx
+		// x1 = x0 - i1 + 1.0 * C.xx
+		// x2 = x0 - 1.0 + 2.0 * C.xx
+		vec4 x12 = x0.xyxy + C.xxzz;
+		x12.xy -= i1;
+
+		// Permutations
+		i = mod289(i); // Avoid truncation effects in permutation
+		vec3 p = permute(permute(i.y + vec3(0.0, i1.y, 1.0)) +
+		         i.x + vec3(0.0, i1.x, 1.0));
+
+		vec3 m = max(0.5 - vec3(dot(x0, x0), dot(x12.xy, x12.xy),
+		                        dot(x12.zw, x12.zw)), 0.0);
+		m = m*m;
+		m = m*m;
+
+		// Gradients: 41 points uniformly over a line, mapped onto a diamond
+		// The ring size 17*17 = 289 is close to a multiple of 41 (41*7 = 287)
+		vec3 x = 2.0 * fract(p * C.www) - 1.0;
+		vec3 h = abs(x) - 0.5;
+		vec3 ox = floor(x + 0.5);
+		vec3 a0 = x - ox;
+
+		// Normalise gradients implicitly by scaling m
+		// Approximation of: m *= inversesqrt(a0*a0 + h*h);
+		m *= 1.79284291400159 - 0.85373472095314 * (a0 * a0 + h * h);
+
+		// Compute final noise value at P
+		vec3 g;
+		g.x  = a0.x  * x0.x   + h.x  * x0.y;
+		g.yz = a0.yz * x12.xz + h.yz * x12.yw;
+		return 130.0 * dot(m, g);
+	}
+
+	// Displace a texture coordinate by a noise function, limited by the given radius
+	vec2 perturb(vec2 uv, float radius, float scale) {
+		if (radius > 0.0 && scale > 0.0) {
+			vec2 p = uv * scale;
+			float r = snoise(p);
+			float a = snoise(-p) * radians(90);
+			uv += radius * r * vec2(cos(a), sin(a));
+		}
+		return uv;
 	}
 );
 // clang-format on

--- a/src/backend/xrender/xrender.c
+++ b/src/backend/xrender/xrender.c
@@ -852,9 +852,9 @@ static bool xrender_apply_alpha(struct backend_base *base, image_handle image,
 	return true;
 }
 
-static void *
-xrender_create_blur_context(backend_t *base attr_unused, enum blur_method method,
-                            enum backend_image_format format attr_unused, void *args) {
+static void *xrender_create_blur_context(backend_t *base attr_unused, enum blur_method method,
+                                         enum backend_image_format format attr_unused,
+                                         struct blur_args *args) {
 	auto ret = ccalloc(1, struct xrender_blur_context);
 	if (!method || method >= BLUR_METHOD_INVALID) {
 		ret->method = BLUR_METHOD_NONE;

--- a/src/config.c
+++ b/src/config.c
@@ -696,6 +696,8 @@ bool parse_config(options_t *opt, const char *config_file) {
 	    .blur_radius = 3,
 	    .blur_deviation = 0.84089642,
 	    .blur_strength = 5,
+	    .blur_noise_radius = 0,
+	    .blur_noise_scale = 0.005,
 	    .blur_background_frame = false,
 	    .blur_background_fixed = false,
 	    .blur_background_blacklist = NULL,

--- a/src/config.h
+++ b/src/config.h
@@ -431,6 +431,10 @@ typedef struct options {
 	double blur_deviation;
 	// Strength of the dual_kawase blur
 	int blur_strength;
+	// Maximum displacement for noise
+	int blur_noise_radius;
+	// Size of noise features
+	double blur_noise_scale;
 	/// Whether to blur background when the window frame is not opaque.
 	/// Implies blur_background.
 	bool blur_background_frame;

--- a/src/config_libconfig.c
+++ b/src/config_libconfig.c
@@ -1267,6 +1267,9 @@ bool parse_config_libconfig(options_t *opt, const char *config_file) { /*NOLINT(
 
 		config_setting_lookup_float(blur_cfg, "deviation", &opt->blur_deviation);
 		config_setting_lookup_int(blur_cfg, "strength", &opt->blur_strength);
+
+		config_setting_lookup_int(blur_cfg, "noise-radius", &opt->blur_noise_radius);
+		config_setting_lookup_float(blur_cfg, "noise-scale", &opt->blur_noise_scale);
 	}
 
 	// --write-pid-path

--- a/src/options.c
+++ b/src/options.c
@@ -499,6 +499,8 @@ static const struct picom_option picom_options[] = {
     [329] = {"blur-size"                   , INTEGER(blur_radius, 0, INT_MAX)               , "The radius of the blur kernel for 'box' and 'gaussian' blur method."},
     [330] = {"blur-deviation"              , FLOAT(blur_deviation, 0, INFINITY)             , "The standard deviation for the 'gaussian' blur method."},
     [331] = {"blur-strength"               , INTEGER(blur_strength, 0, INT_MAX)             , "The strength level of the 'dual_kawase' blur method."},
+    [343] = {"blur-noise-radius"           , INTEGER(blur_noise_radius, 0, INT_MAX)         , "Maximum displacement for noise."},
+    [344] = {"blur-noise-scale"            , FLOAT(blur_noise_scale, 0, INFINITY)           , "Size of noise features."},
     [333] = {"corner-radius"               , INTEGER(corner_radius, 0, INT_MAX)             , "Sets the radius of rounded window corners. When > 0, the compositor will "
                                                                                               "round the corners of windows. (defaults to 0)."},
     [336] = {"window-shader-fg"            , SHADER(window_shader_fg)                       , "Specify GLSL fragment shader path for rendering window contents. See man "

--- a/src/picom.c
+++ b/src/picom.c
@@ -491,26 +491,26 @@ static bool initialize_blur(session_t *ps) {
 	struct box_blur_args bargs;
 	struct dual_kawase_blur_args dkargs;
 
-	void *args = NULL;
+	struct blur_args *args = NULL;
 	switch (ps->o.blur_method) {
 	case BLUR_METHOD_BOX:
 		bargs.size = ps->o.blur_radius;
-		args = (void *)&bargs;
+		args = (struct blur_args *)&bargs;
 		break;
 	case BLUR_METHOD_KERNEL:
 		kargs.kernel_count = ps->o.blur_kernel_count;
 		kargs.kernels = ps->o.blur_kerns;
-		args = (void *)&kargs;
+		args = (struct blur_args *)&kargs;
 		break;
 	case BLUR_METHOD_GAUSSIAN:
 		gargs.size = ps->o.blur_radius;
 		gargs.deviation = ps->o.blur_deviation;
-		args = (void *)&gargs;
+		args = (struct blur_args *)&gargs;
 		break;
 	case BLUR_METHOD_DUAL_KAWASE:
 		dkargs.size = ps->o.blur_radius;
 		dkargs.strength = ps->o.blur_strength;
-		args = (void *)&dkargs;
+		args = (struct blur_args *)&dkargs;
 		break;
 	default: return true;
 	}

--- a/src/picom.c
+++ b/src/picom.c
@@ -515,6 +515,9 @@ static bool initialize_blur(session_t *ps) {
 	default: return true;
 	}
 
+	args->noise_radius = ps->o.blur_noise_radius;
+	args->noise_scale = ps->o.blur_noise_scale;
+
 	enum backend_image_format format = ps->o.dithered_present
 	                                       ? BACKEND_IMAGE_FORMAT_PIXMAP_HIGH
 	                                       : BACKEND_IMAGE_FORMAT_PIXMAP;

--- a/src/renderer/renderer.c
+++ b/src/renderer/renderer.c
@@ -106,7 +106,8 @@ static bool renderer_init(struct renderer *renderer, struct backend_base *backen
 		    .deviation = gaussian_kernel_std_for_size(shadow_radius, 0.5 / 256.0),
 		};
 		renderer->shadow_blur_context = backend->ops.create_blur_context(
-		    backend, BLUR_METHOD_GAUSSIAN, BACKEND_IMAGE_FORMAT_MASK, &args);
+		    backend, BLUR_METHOD_GAUSSIAN, BACKEND_IMAGE_FORMAT_MASK,
+		    (struct blur_args *)&args);
 		if (!renderer->shadow_blur_context) {
 			log_error("Failed to create shadow blur context");
 			return false;


### PR DESCRIPTION
This patch series adds noise to blur shaders that can be used to create a frosted glass effect.

Noise can be configured using the `--blur-noise-radius` and `--blur-noise-scale` options, or in the `blur` section of the configuration file:

```
blur: {
  method = "dual_kawase";
  strength = 16;
  noise-radius = 80;
  noise-scale = 0.5;
};
```

Closes #1015

## Comparison

dual_kawase blur (strength=16, noise-radius=80, noise-scale=0.5):

| <img width="192" height="192" alt="0-none" src="https://github.com/user-attachments/assets/fd7defe6-678c-4b31-ab8a-9b2ebac373da" /> | <img width="192" height="192" alt="10-r80-s5-kawase" src="https://github.com/user-attachments/assets/7365c85c-addb-4681-8cf8-8ef39db84a99" /> |
| - | - |
| Background | Window |

3x3 box blur with various noise-radius/noise-scale values:

|   | r=10 | r=20 | r=50 |
| - | - | - | - |
| s=0.005 | <img width="96" height="96" alt="1-r10-s005-box" src="https://github.com/user-attachments/assets/1db5d517-09fa-436c-8cb3-00ef8ad8e222" /> | <img width="96" height="96" alt="4-r20-s005-box" src="https://github.com/user-attachments/assets/a93913ac-700e-4aef-9089-fb40af586ee5" /> | <img width="96" height="96" alt="7-r50-s005-box" src="https://github.com/user-attachments/assets/c66d2abe-0615-451b-a61d-f2dae32bc87a" /> |
| s=0.05 | <img width="96" height="96" alt="2-r10-s05-box" src="https://github.com/user-attachments/assets/308da117-58bf-4099-93b6-7a9ae17a0c0c" /> | <img width="96" height="96" alt="5-r20-s05-box" src="https://github.com/user-attachments/assets/058f8369-24bd-47ee-bee1-14068cc39e7a" /> | <img width="96" height="96" alt="8-r50-s05-box" src="https://github.com/user-attachments/assets/7b9d462c-8878-4c2b-958e-7c03e83291d5" /> |
| s=0.5 | <img width="96" height="96" alt="3-r10-s5-box" src="https://github.com/user-attachments/assets/8c390caa-193e-47b7-8bd8-f90496d3edd7" /> | <img width="96" height="96" alt="6-r20-s5-box" src="https://github.com/user-attachments/assets/91db9f17-dac1-4ef0-b4ae-74815a1bb4ef" /> | <img width="96" height="96" alt="9-r50-s5-box" src="https://github.com/user-attachments/assets/28ac87c8-2e73-4805-ae8b-ef16138db55a" /> |