### PR TITLE
Changelog: Feature: Make git an option for easy packaging

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -3,6 +3,7 @@ project('picom', 'c', version: '13',
 
 cc = meson.get_compiler('c')
 
+if get_option('git')
 # use git describe if that's available
 git = find_program('git', required: false)
 if git.found()
@@ -20,6 +21,7 @@ if git.found()
 	if git_repository.returncode() == 0
 		repository = git_repository.stdout().strip()
 	endif
+endif
 endif
 
 add_global_arguments('-DPICOM_VERSION="v'+meson.project_version()+'"', language: 'c')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -10,6 +10,8 @@ option('with_docs', type: 'boolean', value: false, description: 'Build documenta
 
 option('unittest', type: 'boolean', value: false, description: 'Enable unittests in the code')
 
+option('git', type: 'boolean', value: true, description: 'Use git describe if that\'s available')
+
 # Experimental options
 
 option('modularize', type: 'boolean', value: false, description: 'Build with clang\'s module system (experimental)')


### PR DESCRIPTION
This patch would ease packaging of picom at least on FreeBSD since it currently needs to remove all the git-related code in meson.build

Authored by:	Vladimir Druzenko <vvd@FreeBSD.org>
See also:	https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=295255#c4