### PR TITLE
Update rounded corners shader to only redraw the corners

### DIFF
--- a/src/backend/gl/shaders.c
+++ b/src/backend/gl/shaders.c
@@ -166,6 +166,15 @@ const char blit_shader_glsl[] = GLSL(330,
 		return vec2(l, l / (max(d.x, d.y) + 1e-8));
 	}
 
+	float rect_sdf_corner_only(vec2 point, vec2 half_size){
+		vec2 d = abs(point) - half_size + vec2(corner_radius);
+		if(d.x>0.0 && d.y>0.0){
+			return length(d)-corner_radius;
+		}
+
+		return -1.0;
+	}
+
 	vec4 default_post_processing(vec4 c) {
 		vec4 border_color = texture(tex, vec2(0.0, 0.5));
 		if (invert_color) {
@@ -205,7 +214,7 @@ const char blit_shader_glsl[] = GLSL(330,
 			// Add a small number to sdf.y to avoid 0/0
 			if (rect_distance > 0.0f) {
 				c = (1.0f - clamp(rect_distance, 0.0f, sdf.y) / (sdf.y + 1e-8)) * rim_color;
-			} else {
+			} else if(rect_sdf_corner_only(texcoord-outer_size/2.0f,inner_size/2.0f) > 0.0f) {
 				float factor = clamp(rect_distance + border_width, 0.0f, sdf.y) / (sdf.y + 1e-8);
 				c = (1.0f - factor) * c + factor * border_color;
 			}


### PR DESCRIPTION
## Summary
Currently the rounded corner shader draws the entire window and redraws the entire border. This patch makes the shader only redraw the rounded corners and keep the sides of the border intact which fixes #1519 where the shader overdrawn the border indicator in i3 window manager.

Comparison images highlighting in red what is redrawn:
Current behavior
<img width="1366" height="768" alt="2026-06-10-120854_1366x768_scrot" src="https://github.com/user-attachments/assets/784272f2-a393-4336-82b7-5d7f6f7c3182" />

with this patch
<img width="1366" height="768" alt="2026-06-10-120906_1366x768_scrot" src="https://github.com/user-attachments/assets/0ea16bf3-cdf1-419b-9c02-32e9a7f4983b" />

image of rounded borders and i3 border indicator working correctly using this patch
<img width="1366" height="768" alt="2026-06-10-140348_1366x768_scrot" src="https://github.com/user-attachments/assets/fa9eb2fc-408b-4a33-ada2-9f8ec35b8ce1" />
