### PR TITLE
WIP: Eliminate synchronous X round trips from the interactive resize path

### DIFF
--- a/include/picom/backend.h
+++ b/include/picom/backend.h
@@ -159,6 +159,11 @@ struct backend_blit_args {
 	/// Effective size of the source image BEFORE scaling, set where the corners
 	/// of the image are.
 	ivec2 effective_size;
+	/// Sampling beyond the source image extent replicates the edge pixels
+	/// instead of tiling. Set for window content: during an interactive grow
+	/// the bound pixmap can briefly be smaller than the window, and tiling
+	/// would mosaic stale content across it.
+	bool edge_clamp;
 	/// Border width of the source image BEFORE scaling. This is used with
 	/// `corner_radius` to create a border for the rounded corners.
 	/// Setting this has no effect if `corner_radius` is 0.

--- a/include/picom/backend.h
+++ b/include/picom/backend.h
@@ -375,10 +375,14 @@ struct backend_operations {
 	/// @param backend_data backend data
 	/// @param pixmap       X pixmap to bind
 	/// @param fmt          information of the pixmap's visual
+	/// @param size_hint    the pixmap's size, if the caller knows it; {0, 0}
+	///                     makes the backend query the X server (a synchronous
+	///                     round trip — avoid in the frame path).
 	/// @return             backend specific image handle for the pixmap. May be
 	///                     NULL.
 	image_handle (*bind_pixmap)(struct backend_base *backend_data, xcb_pixmap_t pixmap,
-	                            struct xvisual_info fmt) __attribute__((nonnull(1)));
+	                            struct xvisual_info fmt, ivec2 size_hint)
+	    __attribute__((nonnull(1)));
 
 	/// Acquire the image handle of the back buffer.
 	///

--- a/src/backend/driver.c
+++ b/src/backend/driver.c
@@ -20,13 +20,12 @@ void apply_driver_workarounds(struct session *ps, enum driver driver) {
 }
 
 enum vblank_scheduler_type choose_vblank_scheduler(enum driver driver attr_unused) {
-	enum vblank_scheduler_type type = VBLANK_SCHEDULER_PRESENT;
-#ifdef CONFIG_OPENGL
-	if (driver & DRIVER_NVIDIA) {
-		type = VBLANK_SCHEDULER_SGI_VIDEO_SYNC;
-	}
-#endif
-	return type;
+	// Present is used on all drivers, including NVIDIA. The sgi_video_sync
+	// scheduler syncs to a single driver-chosen head, which caps multi-head
+	// setups at that monitor's refresh rate, while Present NotifyMSC events
+	// follow the primary monitor's full rate. Revert per-run with
+	// PICOM_DEBUG=force_vblank_sched=sgi_video_sync.
+	return VBLANK_SCHEDULER_PRESENT;
 }
 
 enum driver detect_driver(xcb_connection_t *c, backend_t *backend_data, xcb_window_t window) {

--- a/src/backend/dummy/dummy.c
+++ b/src/backend/dummy/dummy.c
@@ -104,8 +104,9 @@ bool dummy_blur(struct backend_base *base, ivec2 origin attr_unused, image_handl
 	return true;
 }
 
-image_handle dummy_bind_pixmap(struct backend_base *base, xcb_pixmap_t pixmap,
-                               struct xvisual_info fmt attr_unused) {
+image_handle
+dummy_bind_pixmap(struct backend_base *base, xcb_pixmap_t pixmap,
+                  struct xvisual_info fmt attr_unused, ivec2 size_hint attr_unused) {
 	auto dummy = (struct dummy_data *)base;
 	struct dummy_image *img = NULL;
 	HASH_FIND_INT(dummy->pixmap_images, &pixmap, img);

--- a/src/backend/gl/egl.c
+++ b/src/backend/gl/egl.c
@@ -234,24 +234,27 @@ end:
 	return &gd->gl.base;
 }
 
-static image_handle
-egl_bind_pixmap(backend_t *base, xcb_pixmap_t pixmap, struct xvisual_info fmt) {
+static image_handle egl_bind_pixmap(backend_t *base, xcb_pixmap_t pixmap,
+                                    struct xvisual_info fmt, ivec2 size_hint) {
 	struct egl_data *gd = (void *)base;
 	EGLImage *eglpixmap = NULL;
 
-	auto r =
-	    xcb_get_geometry_reply(base->c->c, xcb_get_geometry(base->c->c, pixmap), NULL);
-	if (!r) {
-		log_error("Invalid pixmap %#010x", pixmap);
-		return NULL;
+	if (size_hint.width <= 0 || size_hint.height <= 0) {
+		auto r = xcb_get_geometry_reply(
+		    base->c->c, xcb_get_geometry(base->c->c, pixmap), NULL);
+		if (!r) {
+			log_error("Invalid pixmap %#010x", pixmap);
+			return NULL;
+		}
+		size_hint = (ivec2){.width = r->width, .height = r->height};
+		free(r);
 	}
 
 	log_trace("Binding pixmap %#010x", pixmap);
 	auto inner = ccalloc(1, struct gl_texture);
 	inner->format = BACKEND_IMAGE_FORMAT_PIXMAP;
-	inner->width = r->width;
-	inner->height = r->height;
-	free(r);
+	inner->width = size_hint.width;
+	inner->height = size_hint.height;
 
 	log_debug("depth %d", fmt.visual_depth);
 

--- a/src/backend/gl/egl.c
+++ b/src/backend/gl/egl.c
@@ -213,7 +213,13 @@ static backend_t *egl_init(session_t *ps, xcb_window_t target) {
 
 	gd->gl.release_user_data = egl_release_image;
 
-	if (ps->o.vsync) {
+	// Same reasoning as the glx backend: when frame pacing will engage, the
+	// vblank scheduler already aligns renders to vblank and a blocking swap
+	// would serialize us on the driver's chosen sync display, capping
+	// multi-head setups at one monitor's rate.
+	bool will_frame_pace =
+	    ps->o.frame_pacing && ps->o.vsync && !ps->o.benchmark && ps->c.e.has_present;
+	if (ps->o.vsync && !(will_frame_pace && !global_debug_options.blocking_swap)) {
 		if (!egl_set_swap_interval(1, gd->display)) {
 			log_error("Failed to enable vsync. %#x", eglGetError());
 		}
@@ -301,8 +307,11 @@ static int egl_buffer_age(backend_t *base) {
 	}
 
 	struct egl_data *gd = (void *)base;
-	EGLint val;
-	eglQuerySurface(gd->display, (EGLSurface)gd->target_win, EGL_BUFFER_AGE_EXT, &val);
+	EGLint val = 0;
+	if (!eglQuerySurface(gd->display, (EGLSurface)gd->target_win, EGL_BUFFER_AGE_EXT, &val)) {
+		// Query failed, buffer contents must be assumed undefined.
+		return -1;
+	}
 	return (int)val ?: -1;
 }
 

--- a/src/backend/gl/gl_common.c
+++ b/src/backend/gl/gl_common.c
@@ -565,7 +565,8 @@ gl_lower_blit_args(struct gl_data *gd, ivec2 origin, const struct backend_blit_a
 	double dim_compat = 1.0 - (args->tint.red + args->tint.green + args->tint.blue) / 3.0;
 	// clang-format off
 	auto tex_sampler = vec2_eq(args->scale, SCALE_IDENTITY) ?
-	    gd->samplers[GL_SAMPLER_REPEAT] : gd->samplers[GL_SAMPLER_REPEAT_SCALE];
+	    gd->samplers[args->edge_clamp ? GL_SAMPLER_EDGE : GL_SAMPLER_REPEAT] :
+	    gd->samplers[args->edge_clamp ? GL_SAMPLER_BLUR : GL_SAMPLER_REPEAT_SCALE];
 	struct gl_uniform_value from_uniforms[] = {
 	    [UNIFORM_OPACITY_LOC]        = {.type = GL_FLOAT, .f = (float)args->tint.alpha},
 	    [UNIFORM_INVERT_COLOR_LOC]   = {.type = GL_INT, .i = args->color_inverted},

--- a/src/backend/gl/glx.c
+++ b/src/backend/gl/glx.c
@@ -348,8 +348,8 @@ end:
 	return &gd->gl.base;
 }
 
-static image_handle
-glx_bind_pixmap(backend_t *base, xcb_pixmap_t pixmap, struct xvisual_info fmt) {
+static image_handle glx_bind_pixmap(backend_t *base, xcb_pixmap_t pixmap,
+                                    struct xvisual_info fmt, ivec2 size_hint) {
 	GLXPixmap *glxpixmap = NULL;
 	auto gd = (struct _glx_data *)base;
 
@@ -358,19 +358,22 @@ glx_bind_pixmap(backend_t *base, xcb_pixmap_t pixmap, struct xvisual_info fmt) {
 		return NULL;
 	}
 
-	auto r =
-	    xcb_get_geometry_reply(base->c->c, xcb_get_geometry(base->c->c, pixmap), NULL);
-	if (!r) {
-		log_error("Invalid pixmap %#010x", pixmap);
-		return NULL;
+	if (size_hint.width <= 0 || size_hint.height <= 0) {
+		auto r = xcb_get_geometry_reply(
+		    base->c->c, xcb_get_geometry(base->c->c, pixmap), NULL);
+		if (!r) {
+			log_error("Invalid pixmap %#010x", pixmap);
+			return NULL;
+		}
+		size_hint = (ivec2){.width = r->width, .height = r->height};
+		free(r);
 	}
 
 	log_trace("Binding pixmap %#010x", pixmap);
 	auto inner = ccalloc(1, struct gl_texture);
-	inner->width = r->width;
-	inner->height = r->height;
+	inner->width = size_hint.width;
+	inner->height = size_hint.height;
 	inner->format = BACKEND_IMAGE_FORMAT_PIXMAP;
-	free(r);
 
 	struct glx_fbconfig_cache *cached_fbconfig = NULL;
 	HASH_FIND(hh, gd->cached_fbconfigs, &fmt, sizeof(fmt), cached_fbconfig);

--- a/src/backend/gl/glx.c
+++ b/src/backend/gl/glx.c
@@ -325,11 +325,23 @@ static backend_t *glx_init(session_t *ps, xcb_window_t target) {
 
 	gd->gl.release_user_data = glx_release_image;
 
-	if (ps->o.vsync) {
+	// Whether frame pacing will actually engage. This must mirror the
+	// conditions checked in `initialize_backend` (which runs after backend
+	// init): frame pacing additionally requires vsync, no benchmark mode,
+	// and the Present extension. This backend always provides
+	// last_render_time, so that condition is vacuous here.
+	bool will_frame_pace =
+	    ps->o.frame_pacing && ps->o.vsync && !ps->o.benchmark && ps->c.e.has_present;
+	if (ps->o.vsync && !(will_frame_pace && !global_debug_options.blocking_swap)) {
 		if (!glx_set_swap_interval(1, ps->c.dpy, tgt)) {
 			log_error("Failed to enable vsync.");
 		}
 	} else {
+		// With frame pacing, the vblank scheduler already aligns renders
+		// to vblank; a blocking swap would additionally serialize us on
+		// the driver's chosen sync display (the slowest monitor, on
+		// NVIDIA multi-head), capping every monitor at that rate. Use
+		// PICOM_DEBUG=blocking_swap to get the old behavior.
 		glx_set_swap_interval(0, ps->c.dpy, tgt);
 	}
 
@@ -456,7 +468,11 @@ static int glx_buffer_age(backend_t *base) {
 	}
 
 	struct _glx_data *gd = (void *)base;
-	unsigned int val;
+	// glXQueryDrawable reports failure asynchronously via the X error
+	// handler and leaves the out-param untouched. Pre-set it to 0 (the
+	// spec value for "undefined contents") so a failed query degrades to
+	// a full repaint instead of reading uninitialized stack.
+	unsigned int val = 0;
 	glXQueryDrawable(base->c->dpy, gd->target_win, GLX_BACK_BUFFER_AGE_EXT, &val);
 	return (int)val ?: -1;
 }

--- a/src/backend/gl/shaders.c
+++ b/src/backend/gl/shaders.c
@@ -166,6 +166,15 @@ const char blit_shader_glsl[] = GLSL(330,
 		return vec2(l, l / (max(d.x, d.y) + 1e-8));
 	}
 
+	float rect_sdf_corner_only(vec2 point, vec2 half_size){
+		vec2 d = abs(point) - half_size + vec2(corner_radius);
+		if(d.x>0.0 && d.y>0.0){
+			return length(d)-corner_radius;
+		}
+
+		return -1.0;
+	}
+
 	vec4 default_post_processing(vec4 c) {
 		vec4 border_color = texture(tex, vec2(0.0, 0.5));
 		if (invert_color) {
@@ -205,7 +214,7 @@ const char blit_shader_glsl[] = GLSL(330,
 			// Add a small number to sdf.y to avoid 0/0
 			if (rect_distance > 0.0f) {
 				c = (1.0f - clamp(rect_distance, 0.0f, sdf.y) / (sdf.y + 1e-8)) * rim_color;
-			} else {
+			} else if(rect_sdf_corner_only(texcoord-outer_size/2.0f,inner_size/2.0f) > 0.0f) {
 				float factor = clamp(rect_distance + border_width, 0.0f, sdf.y) / (sdf.y + 1e-8);
 				c = (1.0f - factor) * c + factor * border_color;
 			}

--- a/src/backend/xrender/xrender.c
+++ b/src/backend/xrender/xrender.c
@@ -685,25 +685,27 @@ static bool xrender_blur(struct backend_base *base, ivec2 origin,
 	return true;
 }
 
-static image_handle
-xrender_bind_pixmap(backend_t *base, xcb_pixmap_t pixmap, struct xvisual_info fmt) {
-	xcb_generic_error_t *e;
-	auto r = xcb_get_geometry_reply(base->c->c, xcb_get_geometry(base->c->c, pixmap), &e);
-	if (!r) {
-		log_error("Invalid pixmap: %#010x", pixmap);
-		x_print_error(base->c, e->full_sequence, e->major_code, e->minor_code,
-		              e->error_code);
-		free(e);
-		return NULL;
+static image_handle xrender_bind_pixmap(backend_t *base, xcb_pixmap_t pixmap,
+                                        struct xvisual_info fmt, ivec2 size_hint) {
+	if (size_hint.width <= 0 || size_hint.height <= 0) {
+		xcb_generic_error_t *e;
+		auto r = xcb_get_geometry_reply(base->c->c,
+		                                xcb_get_geometry(base->c->c, pixmap), &e);
+		if (!r) {
+			log_error("Invalid pixmap: %#010x", pixmap);
+			x_print_error(base->c, e->full_sequence, e->major_code,
+			              e->minor_code, e->error_code);
+			free(e);
+			return NULL;
+		}
+		size_hint = (ivec2){.width = r->width, .height = r->height};
+		free(r);
 	}
 
 	auto img = ccalloc(1, struct xrender_image_data_inner);
 	img->depth = (uint8_t)fmt.visual_depth;
 	img->has_alpha = fmt.alpha_size > 0;
-	img->size = (ivec2){
-	    .width = r->width,
-	    .height = r->height,
-	};
+	img->size = size_hint;
 	img->format = BACKEND_IMAGE_FORMAT_PIXMAP;
 	img->pixmap = pixmap;
 	xcb_render_create_picture_value_list_t pic_attrs = {.repeat = XCB_RENDER_REPEAT_NORMAL};
@@ -713,7 +715,6 @@ xrender_bind_pixmap(backend_t *base, xcb_pixmap_t pixmap, struct xvisual_info fm
 	img->pictfmt = pictfmt_info->id;
 	assert(pictfmt_info->depth == img->depth);
 	img->is_pixmap_internal = false;
-	free(r);
 
 	if (img->pict == XCB_NONE) {
 		free(img);

--- a/src/c2.c
+++ b/src/c2.c
@@ -2231,6 +2231,29 @@ void c2_window_state_update(struct c2_state *state, struct c2_window_state *wind
 	c2_window_state_update_from_replies(state, window_state, c, client_win, frame_win);
 }
 
+void c2_window_state_update_from_async_reply(struct c2_state *state,
+                                             struct c2_window_state *window_state,
+                                             xcb_atom_t property, bool is_on_client,
+                                             xcb_get_property_reply_t *reply,
+                                             xcb_connection_t *c) {
+	struct c2_tracked_property *p;
+	struct c2_tracked_property_key key = {
+	    .property = property,
+	    .is_on_client = is_on_client,
+	};
+	HASH_FIND(hh, state->tracked_properties, &key, sizeof(key), p);
+	if (!p) {
+		return;
+	}
+	auto value = &window_state->values[p->id];
+	if (reply == NULL) {
+		value->valid = false;
+		value->needs_update = false;
+		return;
+	}
+	c2_window_state_update_one_from_reply(state, value, property, reply, c);
+}
+
 bool c2_state_is_property_tracked(struct c2_state *state, xcb_atom_t property) {
 	struct c2_tracked_property *p;
 	struct c2_tracked_property_key key = {

--- a/src/c2.h
+++ b/src/c2.h
@@ -45,6 +45,13 @@ struct c2_state *c2_state_new(struct atom *atoms);
 void c2_state_free(struct c2_state *state);
 /// Returns true if value of the property is used in any condition.
 bool c2_state_is_property_tracked(struct c2_state *state, xcb_atom_t property);
+/// Consume an asynchronously fetched GetProperty reply for a tracked property.
+/// `reply` may be NULL to mark the value invalid (fetch failed).
+void c2_window_state_update_from_async_reply(struct c2_state *state,
+                                             struct c2_window_state *window_state,
+                                             xcb_atom_t property, bool is_on_client,
+                                             xcb_get_property_reply_t *reply,
+                                             xcb_connection_t *c);
 void c2_window_state_init(const struct c2_state *state, struct c2_window_state *window_state);
 void c2_window_state_destroy(const struct c2_state *state, struct c2_window_state *window_state);
 void c2_window_state_mark_dirty(const struct c2_state *state,

--- a/src/config.c
+++ b/src/config.c
@@ -525,6 +525,7 @@ static const struct debug_options_entry debug_options_entries[] = {
     {"smart_frame_pacing"   , NULL                , offsetof(struct debug_options, smart_frame_pacing)},
     {"force_vblank_sched"   , vblank_scheduler_str, offsetof(struct debug_options, force_vblank_scheduler)},
     {"consistent_buffer_age", NULL                , offsetof(struct debug_options, consistent_buffer_age)},
+    {"blocking_swap"        , NULL                , offsetof(struct debug_options, blocking_swap)},
 };
 // clang-format on
 

--- a/src/config.h
+++ b/src/config.h
@@ -186,6 +186,12 @@ struct debug_options {
 	/// ensuring no matter what buffer age apitrace gets during replay, the result
 	/// will be the same.
 	int consistent_buffer_age;
+	/// Use a blocking buffer swap (swap interval 1) even when frame pacing is
+	/// active. By default frame pacing implies a non-blocking swap, because the
+	/// vblank scheduler already aligns renders to vblank, and a blocking swap
+	/// serializes the compositor on the driver's chosen sync display — capping
+	/// multi-head setups at one monitor's refresh rate on NVIDIA.
+	int blocking_swap;
 };
 
 extern struct debug_options global_debug_options;

--- a/src/event.c
+++ b/src/event.c
@@ -527,6 +527,132 @@ static inline void ev_expose(session_t *ps, xcb_expose_event_t *ev) {
 	}
 }
 
+struct ev_name_fetch_request {
+	struct x_async_request_base base;
+	struct session *ps;
+	xcb_window_t wid;
+	/// The atom this request fetched; on an empty _NET_WM_NAME reply the
+	/// callback falls back to fetching WM_NAME.
+	xcb_atom_t property;
+};
+
+static void
+handle_name_fetch_reply(struct x_connection *c, struct x_async_request_base *req_base,
+                        const xcb_raw_generic_event_t *reply_or_error);
+
+/// Fetch the window title asynchronously: _NET_WM_NAME first, WM_NAME as
+/// fallback (same priority as the synchronous `win_update_name`).
+static void ev_name_fetch_start_atom(session_t *ps, xcb_window_t client_wid,
+                                     xcb_window_t toplevel_wid, xcb_atom_t atom) {
+	auto req = ccalloc(1, struct ev_name_fetch_request);
+	req->base.sequence = xcb_get_property(ps->c.c, 0, client_wid, atom,
+	                                      XCB_GET_PROPERTY_TYPE_ANY, 0, UINT_MAX)
+	                         .sequence;
+	req->base.callback = handle_name_fetch_reply;
+	req->ps = ps;
+	req->wid = toplevel_wid;
+	req->property = atom;
+	x_await_request(&ps->c, &req->base);
+}
+
+static void ev_name_fetch_start(session_t *ps, struct wm_ref *toplevel_cursor) {
+	auto client_cursor = wm_ref_client_of(toplevel_cursor) ?: toplevel_cursor;
+	ev_name_fetch_start_atom(ps, wm_ref_win_id(client_cursor),
+	                         wm_ref_win_id(toplevel_cursor), ps->atoms->a_NET_WM_NAME);
+}
+
+static void handle_name_fetch_reply(struct x_connection *c attr_unused,
+                                    struct x_async_request_base *req_base,
+                                    const xcb_raw_generic_event_t *reply_or_error) {
+	auto req = (struct ev_name_fetch_request *)req_base;
+	auto ps = req->ps;
+	auto wid = req->wid;
+	auto property = req->property;
+	free(req);
+
+	if (reply_or_error == NULL || reply_or_error->response_type == 0) {
+		return;
+	}
+
+	auto cursor = wm_find(ps->wm, wid);
+	auto w = cursor != NULL ? wm_ref_deref(cursor) : NULL;
+	if (w == NULL) {
+		return;
+	}
+
+	auto reply = (xcb_get_property_reply_t *)reply_or_error;
+	if ((reply->type == XCB_ATOM_NONE || reply->format != 8 ||
+	     xcb_get_property_value_length(reply) == 0) &&
+	    property == ps->atoms->a_NET_WM_NAME) {
+		// _NET_WM_NAME unset; fall back to WM_NAME.
+		auto client_cursor = wm_ref_client_of(cursor) ?: cursor;
+		ev_name_fetch_start_atom(ps, wm_ref_win_id(client_cursor), wid,
+		                         ps->atoms->aWM_NAME);
+		return;
+	}
+	if (reply->type == XCB_ATOM_NONE || reply->format != 8 ||
+	    !x_is_type_string(ps->atoms, reply->type)) {
+		return;
+	}
+
+	int len = xcb_get_property_value_length(reply);
+	const char *data = xcb_get_property_value(reply);
+	// The name is the first (possibly not null-terminated) string.
+	int name_len = (int)strnlen(data, (size_t)len);
+	if (w->name != NULL && strncmp(w->name, data, (size_t)name_len) == 0 &&
+	    w->name[name_len] == '\0') {
+		return;        // unchanged
+	}
+	free(w->name);
+	w->name = strndup(data, (size_t)name_len);
+	win_set_flags(w, WIN_FLAGS_FACTOR_CHANGED);
+	ps->pending_updates = true;
+	queue_redraw(ps);
+}
+
+struct ev_c2_property_fetch_request {
+	struct x_async_request_base base;
+	struct session *ps;
+	xcb_window_t wid;
+	xcb_atom_t property;
+	bool is_on_client;
+};
+
+/// Reply handler for the async GetProperty issued when a c2-tracked property
+/// changes. Updates the cached value and re-evaluates rules.
+static void handle_c2_property_fetch_reply(struct x_connection *c,
+                                           struct x_async_request_base *req_base,
+                                           const xcb_raw_generic_event_t *reply_or_error) {
+	auto req = (struct ev_c2_property_fetch_request *)req_base;
+	auto ps = req->ps;
+	auto wid = req->wid;
+	auto property = req->property;
+	auto is_on_client = req->is_on_client;
+	free(req);
+
+	if (reply_or_error == NULL) {
+		// Shutting down
+		return;
+	}
+
+	auto cursor = wm_find(ps->wm, wid);
+	auto w = cursor != NULL ? wm_ref_deref(cursor) : NULL;
+	if (w == NULL) {
+		return;
+	}
+
+	xcb_get_property_reply_t *reply = NULL;
+	if (reply_or_error->response_type != 0) {
+		reply = (xcb_get_property_reply_t *)reply_or_error;
+	}
+	c2_window_state_update_from_async_reply(ps->c2_state, &w->c2_state, property,
+	                                        is_on_client, reply, c->c);
+	// Rules based on this property must be re-evaluated.
+	win_set_flags(w, WIN_FLAGS_FACTOR_CHANGED);
+	ps->pending_updates = true;
+	queue_redraw(ps);
+}
+
 static inline void ev_property_notify(session_t *ps, xcb_property_notify_event_t *ev) {
 	log_debug("{ atom = %#010x, window = %#010x, state = %d }", ev->atom, ev->window,
 	          ev->state);
@@ -597,7 +723,15 @@ static inline void ev_property_notify(session_t *ps, xcb_property_notify_event_t
 	}
 
 	auto toplevel = wm_ref_deref(toplevel_cursor);
-	if (toplevel) {
+	if (toplevel != NULL &&
+	    (ev->atom == ps->atoms->aWM_NAME || ev->atom == ps->atoms->a_NET_WM_NAME)) {
+		// Terminals stamp the window title with the size on every resize
+		// step; the synchronous name refetch in win_update_properties (2
+		// blocking round trips) then stalls the next frame against a
+		// maximally busy X server. Fetch the name asynchronously instead;
+		// _NET_WM_NAME keeps priority via a chained WM_NAME fallback.
+		ev_name_fetch_start(ps, toplevel_cursor);
+	} else if (toplevel) {
 		win_set_property_stale(toplevel, ev->atom);
 	}
 
@@ -612,13 +746,22 @@ static inline void ev_property_notify(session_t *ps, xcb_property_notify_event_t
 	if (c2_state_is_property_tracked(ps->c2_state, ev->atom)) {
 		bool change_is_on_client = cursor == client_cursor;
 		if (toplevel) {
-			c2_window_state_mark_dirty(ps->c2_state, &toplevel->c2_state,
-			                           ev->atom, change_is_on_client);
-			// Set FACTOR_CHANGED so rules based on properties will be
-			// re-evaluated.
-			// Don't need to set property stale here, since that only
-			// concerns properties we explicitly check.
-			win_set_flags(toplevel, WIN_FLAGS_FACTOR_CHANGED);
+			// Fetch the new value asynchronously right away instead of
+			// marking it dirty for a synchronous fetch at the next frame:
+			// the blocking GetProperty round trip in the draw callback
+			// stalled resize frames for tens of milliseconds (GTK clients
+			// stamp properties continuously while resizing).
+			auto req = ccalloc(1, struct ev_c2_property_fetch_request);
+			req->base.sequence =
+			    xcb_get_property(ps->c.c, 0, wm_ref_win_id(cursor), ev->atom,
+			                     XCB_GET_PROPERTY_TYPE_ANY, 0, UINT32_MAX)
+			        .sequence;
+			req->base.callback = handle_c2_property_fetch_reply;
+			req->ps = ps;
+			req->wid = win_id(toplevel);
+			req->property = ev->atom;
+			req->is_on_client = change_is_on_client;
+			x_await_request(&ps->c, &req->base);
 		}
 	}
 }

--- a/src/event.c
+++ b/src/event.c
@@ -702,7 +702,26 @@ static inline void ev_shape_notify(session_t *ps, xcb_shape_notify_event_t *ev) 
 		return;
 	}
 
-	win_set_flags(w, WIN_FLAGS_SIZE_STALE);
+	log_debug("Shape notify for %#010x (%s): kind %d, shaped %d, %dx%d", win_id(w),
+	          w->name, ev->shape_kind, ev->shaped, ev->extents_width, ev->extents_height);
+
+	if (ev->shape_kind == XCB_SHAPE_SK_INPUT) {
+		// Input shape doesn't affect rendering at all; rebinding the
+		// pixmap and re-rendering for it is pure waste.
+		return;
+	}
+
+	// A shape change only affects which region of the pixmap is drawn; the
+	// pixmap itself is still valid. SIZE_STALE would needlessly rebind it.
+	//
+	// The event itself carries whether the window is (still) shaped —
+	// recording it here means the update path never needs a synchronous
+	// ShapeQueryExtents round trip. i3 stamps ShapeNotify on every frame
+	// window on every resize step, so querying instead of trusting the
+	// event cost ~2-4ms × windows × frames (measured 29-44ms/frame).
+	w->bounding_shaped = ev->shaped;
+	w->shape_known = true;
+	win_set_flags(w, WIN_FLAGS_SHAPE_STALE);
 	ps->pending_updates = true;
 }
 

--- a/src/event.c
+++ b/src/event.c
@@ -8,6 +8,7 @@
 #include <xcb/damage.h>
 #include <xcb/randr.h>
 #include <xcb/xcb_event.h>
+#include <xcb/xfixes.h>
 #include <xcb/xproto.h>
 
 #include <picom/types.h>
@@ -622,57 +623,94 @@ static inline void ev_property_notify(session_t *ps, xcb_property_notify_event_t
 	}
 }
 
+struct ev_damage_fetch_request {
+	struct x_async_request_base base;
+	struct session *ps;
+	xcb_window_t wid;
+};
+
+/// Reply handler for the async XFixesFetchRegion issued by `repair_win`.
+static void handle_damage_fetch_reply(struct x_connection *c attr_unused,
+                                      struct x_async_request_base *req_base,
+                                      const xcb_raw_generic_event_t *reply_or_error) {
+	auto req = (struct ev_damage_fetch_request *)req_base;
+	auto ps = req->ps;
+	auto wid = req->wid;
+	free(req);
+
+	if (reply_or_error == NULL || reply_or_error->response_type == 0) {
+		// Shutting down, or the window vanished mid-flight.
+		return;
+	}
+
+	auto cursor = wm_find(ps->wm, wid);
+	auto w = cursor != NULL ? wm_ref_deref(cursor) : NULL;
+	if (w == NULL || !ps->redirected) {
+		// Why care about damage when screen is unredirected?
+		// We will force full-screen repaint on redirection.
+		return;
+	}
+
+	auto reply = (xcb_xfixes_fetch_region_reply_t *)reply_or_error;
+	int nrect = xcb_xfixes_fetch_region_rectangles_length(reply);
+	xcb_rectangle_t *xrect = xcb_xfixes_fetch_region_rectangles(reply);
+	region_t parts;
+	pixman_region32_init(&parts);
+	for (int i = 0; i < nrect; i++) {
+		pixman_region32_union_rect(&parts, &parts, xrect[i].x + w->g.border_width,
+		                           xrect[i].y + w->g.border_width, xrect[i].width,
+		                           xrect[i].height);
+	}
+	pixman_region32_union(&w->damaged, &w->damaged, &parts);
+	pixman_region32_fini(&parts);
+	queue_redraw(ps);
+}
+
 static inline void repair_win(session_t *ps, struct win *w) {
 	// Only mapped window can receive damages
 	assert(w->state == WSTATE_MAPPED || win_check_flags_all(w, WIN_FLAGS_MAPPED));
 
-	region_t parts;
-	pixman_region32_init(&parts);
-
 	// If this is the first time this window is damaged, we would redraw the
-	// whole window, so we don't need to fetch the damage region. But we still need
-	// to make sure the X server receives the DamageSubtract request, hence the
-	// `xcb_request_check` here.
-	// Otherwise, we fetch the damage regions. That means we will receive a reply
-	// from the X server, which implies it has received our DamageSubtract request.
+	// whole window, so we don't need to fetch the damage region, just clear
+	// the damage object.
+	// Otherwise, move the accumulated damage into the scratch region and
+	// fetch it ASYNCHRONOUSLY. The old synchronous fetch here was one full X
+	// round trip per DamageNotify — during an interactive resize the client
+	// redraws continuously and the X server is at its busiest, so each event
+	// stalled the event loop for tens of milliseconds. The server executes
+	// the DamageSubtract/FetchRegion pair in submission order, so the shared
+	// scratch region stays correct even with multiple fetches in flight.
 	if (!w->ever_damaged) {
-		auto e = xcb_request_check(
-		    ps->c.c,
-		    xcb_damage_subtract_checked(ps->c.c, w->damage, XCB_NONE, XCB_NONE));
-		if (e) {
-			if (ps->o.show_all_xerrors) {
-				x_print_error(&ps->c, e->sequence, e->major_code,
-				              e->minor_code, e->error_code);
-			}
-			free(e);
+		auto cookie = xcb_damage_subtract(ps->c.c, w->damage, XCB_NONE, XCB_NONE);
+		if (!ps->o.show_all_xerrors) {
+			x_set_error_action_ignore(&ps->c, cookie);
 		}
-		win_extents(w, &parts);
 		log_debug("Window %#010x (%s) has been damaged the first time", win_id(w),
 		          w->name);
+		if (ps->redirected) {
+			region_t parts;
+			pixman_region32_init(&parts);
+			win_extents(w, &parts);
+			pixman_region32_translate(&parts, -w->g.x, -w->g.y);
+			pixman_region32_union(&w->damaged, &w->damaged, &parts);
+			pixman_region32_fini(&parts);
+		}
 	} else {
 		auto cookie = xcb_damage_subtract(ps->c.c, w->damage, XCB_NONE, ps->x_region);
 		if (!ps->o.show_all_xerrors) {
 			x_set_error_action_ignore(&ps->c, cookie);
 		}
-		x_fetch_region(&ps->c, ps->x_region, &parts);
-		pixman_region32_translate(&parts, w->g.x + w->g.border_width,
-		                          w->g.y + w->g.border_width);
+		auto req = ccalloc(1, struct ev_damage_fetch_request);
+		req->base.sequence = xcb_xfixes_fetch_region(ps->c.c, ps->x_region).sequence;
+		req->base.callback = handle_damage_fetch_reply;
+		req->ps = ps;
+		req->wid = win_id(w);
+		x_await_request(&ps->c, &req->base);
 	}
 
 	log_trace("Mark window %#010x (%s) as having received damage", win_id(w), w->name);
 	w->ever_damaged = true;
 	w->pixmap_damaged = true;
-
-	// Why care about damage when screen is unredirected?
-	// We will force full-screen repaint on redirection.
-	if (!ps->redirected) {
-		pixman_region32_fini(&parts);
-		return;
-	}
-
-	pixman_region32_translate(&parts, -w->g.x, -w->g.y);
-	pixman_region32_union(&w->damaged, &w->damaged, &parts);
-	pixman_region32_fini(&parts);
 }
 
 static inline void ev_damage_notify(session_t *ps, xcb_damage_notify_event_t *de) {

--- a/src/picom.c
+++ b/src/picom.c
@@ -2152,6 +2152,17 @@ static session_t *session_init(int argc, char **argv, Display *dpy,
 		          "possible. (xrender-sync-fence can't be enabled)");
 		ps->o.xrender_sync_fence = false;
 	}
+	if (ps->o.xrender_sync_fence && !ps->o.use_legacy_backends &&
+	    ps->o.backend != backend_find("glx")) {
+		// The fence await is a blocking X round trip per frame, and the X
+		// server answers slowest exactly when it's busiest (e.g. relaying an
+		// interactive resize). The workaround it implements is only known to
+		// be needed on NVIDIA GLX.
+		log_warn("xrender-sync-fence is enabled but the backend is not glx. "
+		         "This costs a blocking X round trip every frame (tens of ms "
+		         "under load) and is likely unnecessary on this backend; "
+		         "consider disabling it.");
+	}
 
 	if (ps->o.crop_shadow_to_monitor && !ps->c.e.has_randr) {
 		log_fatal("No X RandR extension. crop-shadow-to-monitor cannot be "

--- a/src/picom.c
+++ b/src/picom.c
@@ -895,7 +895,8 @@ void root_damaged(session_t *ps) {
 			        : x_get_visual_for_depth(ps->c.screen_info, r->depth);
 
 			ps->root_image = ps->backend_data->ops.bind_pixmap(
-			    ps->backend_data, pixmap, x_get_visual_info(&ps->c, visual));
+			    ps->backend_data, pixmap, x_get_visual_info(&ps->c, visual),
+			    (ivec2){.width = r->width, .height = r->height});
 			ps->root_image_generation += 1;
 			ps->root_image_extent = (rect_t){
 			    .x1 = r->x, .x2 = r->x + r->width, .y1 = r->y, .y2 = r->y + r->height};

--- a/src/renderer/command_builder.c
+++ b/src/renderer/command_builder.c
@@ -39,6 +39,13 @@ commands_for_window_body(struct layer *layer, struct backend_command *cmd_base,
 	pixman_region32_copy(&cmd->target_mask, &w->bounding_shape);
 	pixman_region32_translate(&cmd->target_mask, layer->window.origin.x,
 	                          layer->window.origin.y);
+	// The bounding shape spans the window geometry; the layer box may be
+	// clamped to the (smaller) bound image during a grow so decoration
+	// follows content — clip the body to it as well.
+	pixman_region32_intersect_rect(&cmd->target_mask, &cmd->target_mask,
+	                               layer->window.origin.x, layer->window.origin.y,
+	                               (uint)layer->window.size.width,
+	                               (uint)layer->window.size.height);
 	if (w->frame_opacity < 1) {
 		pixman_region32_subtract(&cmd->target_mask, &cmd->target_mask, frame_region);
 	}
@@ -84,6 +91,10 @@ commands_for_window_body(struct layer *layer, struct backend_command *cmd_base,
 	    .color_inverted = layer->options.invert_color,
 	    .source_mask = NULL,
 	    .max_brightness = max_brightness,
+	    // During an interactive grow the bound pixmap can briefly be smaller
+	    // than the window (asynchronous rebind); clamp instead of tiling so
+	    // the gap shows stretched edge pixels, not a mosaic of stale content.
+	    .edge_clamp = true,
 	};
 	region_scale(&cmd->target_mask, layer->window.origin, layer->scale);
 	region_scale(&cmd->opaque_region, layer->window.origin, layer->scale);
@@ -229,7 +240,19 @@ command_for_shadow(struct layer *layer, struct backend_command *cmd,
 		    vec2_reciprocal(layer->shadow_scale));
 	}
 
-	scoped_region_t crop = region_from_box(layer->crop);
+	// Outset the crop by the shadow's margins around the window, so a crop
+	// that tracks the window rect (e.g. crop-reveal geometry animations)
+	// keeps the shadow visible instead of clipping it away entirely.
+	struct ibox shadow_crop = layer->crop;
+	if (shadow_crop.size.width != INT_MAX) {
+		ivec2 margin_tl = ivec2_sub(layer->window.origin, layer->shadow.origin);
+		ivec2 margin_br = ivec2_sub(
+		    ivec2_add(layer->shadow.origin, layer->shadow.size),
+		    ivec2_add(layer->window.origin, layer->window.size));
+		shadow_crop.origin = ivec2_sub(shadow_crop.origin, margin_tl);
+		shadow_crop.size = ivec2_add(shadow_crop.size, ivec2_add(margin_tl, margin_br));
+	}
+	scoped_region_t crop = region_from_box(shadow_crop);
 	pixman_region32_intersect(&cmd->target_mask, &cmd->target_mask, &crop);
 
 	cmd->blit = (struct backend_blit_args){
@@ -256,6 +279,13 @@ command_for_blur(struct layer *layer, struct backend_command *cmd,
 		pixman_region32_copy(&cmd->target_mask, &w->bounding_shape);
 		pixman_region32_translate(&cmd->target_mask, layer->window.origin.x,
 		                          layer->window.origin.y);
+		// Match the body: the layer box may be clamped to the bound image
+		// during a grow (decoration follows content); blur past the drawn
+		// body would show a blurred halo band.
+		pixman_region32_intersect_rect(
+		    &cmd->target_mask, &cmd->target_mask, layer->window.origin.x,
+		    layer->window.origin.y, (uint)layer->window.size.width,
+		    (uint)layer->window.size.height);
 	} else if (blur_frame && mode == WMODE_FRAME_TRANS) {
 		pixman_region32_copy(&cmd->target_mask, frame_region);
 	} else {

--- a/src/renderer/damage.c
+++ b/src/renderer/damage.c
@@ -67,6 +67,109 @@ static inline void region_union_render_layer(region_t *region, const struct laye
 	}
 }
 
+/// Check if two mismatching layers differ ONLY in window/shadow size (same
+/// origin, scale, blend, and command structure). This is the interactive
+/// resize case (with the content pinned, e.g. a crop-reveal animation), for
+/// which we can damage much less than both layers' full extents.
+static bool layer_compare_size_only(const struct layer *past_layer,
+                                    const struct backend_command *past_layer_cmd,
+                                    const struct layer *curr_layer,
+                                    const struct backend_command *curr_layer_cmd) {
+	if (!ivec2_eq(past_layer->window.origin, curr_layer->window.origin) ||
+	    !ivec2_eq(past_layer->shadow.origin, curr_layer->shadow.origin)) {
+		return false;
+	}
+	if (!vec2_eq(past_layer->scale, SCALE_IDENTITY) ||
+	    !vec2_eq(curr_layer->scale, SCALE_IDENTITY) ||
+	    !vec2_eq(past_layer->shadow_scale, SCALE_IDENTITY) ||
+	    !vec2_eq(curr_layer->shadow_scale, SCALE_IDENTITY)) {
+		return false;
+	}
+	if (past_layer->saved_image_blend != curr_layer->saved_image_blend ||
+	    past_layer->opacity != curr_layer->opacity ||
+	    past_layer->blur_opacity != curr_layer->blur_opacity ||
+	    past_layer->number_of_commands != curr_layer->number_of_commands) {
+		return false;
+	}
+	for (unsigned i = 0; i < past_layer->number_of_commands; i++) {
+		auto cmd1 = &past_layer_cmd[i];
+		auto cmd2 = &curr_layer_cmd[i];
+		if (cmd1->op != cmd2->op || !ivec2_eq(cmd1->origin, cmd2->origin) ||
+		    cmd1->source != cmd2->source) {
+			return false;
+		}
+	}
+	return true;
+}
+
+/// Damage for a size-only layer change: instead of both layers' full extents
+/// (which makes every resize frame repaint — and re-blur — the entire window),
+/// damage only what can actually differ:
+///  - the symmetric difference of each command pair's masks (the grown/shrunk
+///    parts),
+///  - the window's own content damage (the client's redraws),
+///  - a band along each moved edge wide enough to cover rounded corners and
+///    the shadow gradient (their pixels change in the overlap when the edge
+///    they hug moves),
+/// all expanded by the blur size, since blur diffuses changes outward.
+static void
+layer_size_change_damage(region_t *damage, region_t *scratch_region,
+                         const struct layer *past_layer, struct backend_command *past_layer_cmd,
+                         const struct layer *curr_layer, struct backend_command *curr_layer_cmd,
+                         const struct layout_manager *lm, unsigned curr_layer_rank,
+                         unsigned buffer_age, ivec2 blur_size) {
+	region_t added;
+	pixman_region32_init(&added);
+
+	int pad = 0;
+	for (unsigned i = 0; i < past_layer->number_of_commands; i++) {
+		auto cmd1 = &past_layer_cmd[i];
+		auto cmd2 = &curr_layer_cmd[i];
+		// Symmetric difference of the pair's masks.
+		region_symmetric_difference_local(&added, scratch_region,
+		                                  &cmd1->target_mask, &cmd2->target_mask);
+		if (cmd1->op == BACKEND_COMMAND_BLIT) {
+			pad = max2(pad, (int)cmd1->blit.corner_radius);
+		}
+	}
+	// The shadow gradient hugs the window border; when an edge moves, pixels
+	// within the shadow margin of that edge change even inside the overlap.
+	pad = max2(
+	    pad, (past_layer->shadow.size.width - past_layer->window.size.width + 1) / 2);
+	pad = max2(
+	    pad, (past_layer->shadow.size.height - past_layer->window.size.height + 1) / 2);
+
+	// Bands along moved edges (right/bottom; origin is pinned in this path so
+	// left/top cannot move), covering both old and new edge positions.
+	auto po = past_layer->shadow.origin;
+	auto ps_sz = past_layer->shadow.size;
+	auto cs_sz = curr_layer->shadow.size;
+	int max_h = max2(ps_sz.height, cs_sz.height);
+	int max_w = max2(ps_sz.width, cs_sz.width);
+	if (ps_sz.width != cs_sz.width) {
+		int edge = min2(po.x + ps_sz.width, po.x + cs_sz.width);
+		pixman_region32_union_rect(&added, &added, edge - pad, po.y,
+		                           (unsigned)(2 * pad), (unsigned)max_h);
+	}
+	if (ps_sz.height != cs_sz.height) {
+		int edge = min2(po.y + ps_sz.height, po.y + cs_sz.height);
+		pixman_region32_union_rect(&added, &added, po.x, edge - pad,
+		                           (unsigned)max_w, (unsigned)(2 * pad));
+	}
+
+	// Content the client redrew. `layer->damaged` is already in screen
+	// coordinates (see layout.c), no translation needed.
+	pixman_region32_clear(scratch_region);
+	layout_manager_collect_window_damage(lm, curr_layer_rank, buffer_age, scratch_region);
+	pixman_region32_union(&added, &added, scratch_region);
+
+	// Blur diffuses changes outward; pad everything by the blur size.
+	resize_region_in_place(&added, blur_size.width, blur_size.height);
+
+	pixman_region32_union(damage, damage, &added);
+	pixman_region32_fini(&added);
+}
+
 static inline void
 command_blit_damage(region_t *damage, region_t *scratch_region, struct backend_command *cmd1,
                     struct backend_command *cmd2, const struct layout_manager *lm,
@@ -302,8 +405,19 @@ void layout_manager_damage(struct layout_manager *lm, unsigned buffer_age,
 		          curr_layer->win->name);
 
 		if (!layer_compare(past_layer, past_layer_cmd, curr_layer, curr_layer_cmd)) {
-			region_union_render_layer(damage, curr_layer, curr_layer_cmd);
-			region_union_render_layer(damage, past_layer, past_layer_cmd);
+			if (layer_compare_size_only(past_layer, past_layer_cmd,
+			                            curr_layer, curr_layer_cmd)) {
+				// Interactive resize with pinned content: damage the
+				// changed bands, not the whole window (which would
+				// re-blur the entire window area every frame).
+				layer_size_change_damage(
+				    damage, &scratch_region, past_layer, past_layer_cmd,
+				    curr_layer, curr_layer_cmd, lm, curr_layer_rank,
+				    buffer_age, blur_size);
+			} else {
+				region_union_render_layer(damage, curr_layer, curr_layer_cmd);
+				region_union_render_layer(damage, past_layer, past_layer_cmd);
+			}
 			continue;
 		}
 

--- a/src/renderer/layout.c
+++ b/src/renderer/layout.c
@@ -59,6 +59,27 @@ static bool layer_from_window(struct layer *out_layer, struct win *w, ivec2 size
 	    vec2_as((vec2){.x = w->g.x + win_animatable_get(w, WIN_SCRIPT_OFFSET_X),
 	                   .y = w->g.y + win_animatable_get(w, WIN_SCRIPT_OFFSET_Y)});
 	out_layer->window.size = vec2_as((vec2){.width = w->widthb, .height = w->heightb});
+	// During a grow, the bound image briefly lags the geometry (async rebind
+	// + the client's own repaint latency); its grown strip would render as
+	// transparent zeroes or a stretched edge. Deferring the content bind
+	// until the client painted was proven unworkable (see win.h,
+	// pending_pixmap_ready) — instead the DECORATION follows the content:
+	// clamp the rendered window box (and, below, the shadow) to the bound
+	// image, so border/shadow/corners hug real pixels and snap out with the
+	// next bind. Shrinks are unaffected (image ≥ geometry).
+	ivec2 deco_shrink = {};
+	if (w->win_image_size.width > 0 && w->win_image_size.height > 0) {
+		if (w->win_image_size.width < out_layer->window.size.width) {
+			deco_shrink.width =
+			    out_layer->window.size.width - w->win_image_size.width;
+			out_layer->window.size.width = w->win_image_size.width;
+		}
+		if (w->win_image_size.height < out_layer->window.size.height) {
+			deco_shrink.height =
+			    out_layer->window.size.height - w->win_image_size.height;
+			out_layer->window.size.height = w->win_image_size.height;
+		}
+	}
 	out_layer->crop.origin = vec2_as((vec2){
 	    .x = win_animatable_get(w, WIN_SCRIPT_CROP_X),
 	    .y = win_animatable_get(w, WIN_SCRIPT_CROP_Y),
@@ -84,7 +105,8 @@ static bool layer_from_window(struct layer *out_layer, struct win *w, ivec2 size
 		                   .y = w->g.y + w->shadow_dy * scale.y +
 		                        win_animatable_get(w, WIN_SCRIPT_SHADOW_OFFSET_Y)});
 		out_layer->shadow.size =
-		    vec2_as((vec2){.width = w->shadow_width, .height = w->shadow_height});
+		    vec2_as((vec2){.width = w->shadow_width - deco_shrink.width,
+		                   .height = w->shadow_height - deco_shrink.height});
 	} else {
 		out_layer->shadow.origin = (ivec2){};
 		out_layer->shadow.size = (ivec2){};

--- a/src/renderer/renderer.c
+++ b/src/renderer/renderer.c
@@ -747,7 +747,7 @@ bool renderer_render(struct renderer *r, struct backend_base *backend,
 		backend->ops.prepare(backend, &layout->commands[0].target_mask);
 	}
 
-	if (monitor_repaint && buffer_age <= r->max_buffer_age) {
+	if (monitor_repaint && buffer_age > 0 && buffer_age <= r->max_buffer_age) {
 		// Restore the area of back buffer that was tainted by monitor repaint
 		int past_frame =
 		    (r->frame_index + r->max_buffer_age - buffer_age) % r->max_buffer_age;

--- a/src/renderer/renderer.c
+++ b/src/renderer/renderer.c
@@ -15,6 +15,18 @@
 #include "picom.h"
 #include "utils/dynarr.h"
 
+/// Cached pre-blurred shadow atlas for one corner radius. The atlas is the
+/// shadow mask of a minimal prototype window; any larger shadow is composed
+/// exactly from it with nine blits (4 corners at 1:1, 4 edges and the center
+/// stretched from translation-invariant bands). See
+/// `renderer_compose_shadow_nine_slice`.
+struct shadow_atlas_entry {
+	unsigned corner_radius;
+	image_handle image;
+};
+
+#define SHADOW_ATLAS_CACHE_SIZE 8
+
 struct renderer {
 	/// Intermediate image to hold what will be presented to the back buffer.
 	image_handle back_image;
@@ -39,6 +51,10 @@ struct renderer {
 	int shadow_radius;
 	void *shadow_blur_context;
 	struct conv *shadow_kernel;
+	/// Shadow atlases keyed by corner radius (shadow radius is fixed per
+	/// renderer). Tiny LRU-less cache; distinct corner radii per config are
+	/// few in practice.
+	struct shadow_atlas_entry shadow_atlas[SHADOW_ATLAS_CACHE_SIZE];
 
 	/// A dynarr of region_t for storing culled masks
 	region_t *culled_masks;
@@ -62,6 +78,12 @@ void renderer_free(struct backend_base *backend, struct renderer *r) {
 	}
 	if (r->shadow_kernel) {
 		free_conv(r->shadow_kernel);
+	}
+	for (size_t i = 0; i < SHADOW_ATLAS_CACHE_SIZE; i++) {
+		if (r->shadow_atlas[i].image != NULL) {
+			backend->ops.release_image(backend, r->shadow_atlas[i].image);
+			r->shadow_atlas[i].image = NULL;
+		}
 	}
 	if (r->monitor_repaint_region) {
 		for (int i = 0; i < r->max_buffer_age; i++) {
@@ -296,15 +318,172 @@ err:
 	return NULL;
 }
 
+/// Get (or build) the shadow atlas for `corner_radius`. The atlas is the full
+/// shadow mask of a prototype window of side `2 * (corner_radius + shadow
+/// radius) + 1`: at that size the four `corner_radius + 2 * shadow_radius`
+/// corner blocks are exact, and the 1px-wide bands between them along each
+/// axis are translation-invariant (a Gaussian of radius r is unaffected by
+/// geometry further than r away), so they can be stretched to any length.
+static image_handle renderer_get_shadow_atlas(struct renderer *r, struct backend_base *backend,
+                                              unsigned corner_radius) {
+	struct shadow_atlas_entry *slot = NULL;
+	for (size_t i = 0; i < SHADOW_ATLAS_CACHE_SIZE; i++) {
+		if (r->shadow_atlas[i].image != NULL &&
+		    r->shadow_atlas[i].corner_radius == corner_radius) {
+			return r->shadow_atlas[i].image;
+		}
+		if (slot == NULL && r->shadow_atlas[i].image == NULL) {
+			slot = &r->shadow_atlas[i];
+		}
+	}
+	if (slot == NULL) {
+		// Cache full; extremely unlikely (needs >8 distinct corner radii).
+		// Caller falls back to full generation.
+		return NULL;
+	}
+
+	int proto = 2 * ((int)corner_radius + r->shadow_radius) + 1;
+	ivec2 proto_size = {.width = proto, .height = proto};
+
+	// Rasterize the prototype's shape mask (rounded rect) then blur it, using
+	// the exact same pipeline as full shadow generation so results match.
+	auto proto_mask =
+	    backend->ops.new_image(backend, BACKEND_IMAGE_FORMAT_MASK, proto_size);
+	if (proto_mask == NULL ||
+	    !backend->ops.clear(backend, proto_mask, (struct color){0, 0, 0, 0})) {
+		if (proto_mask != NULL) {
+			backend->ops.release_image(backend, proto_mask);
+		}
+		return NULL;
+	}
+	{
+		region_t target;
+		pixman_region32_init_rect(&target, 0, 0, (unsigned)proto, (unsigned)proto);
+		struct backend_blit_args args = {
+		    .source_image = r->white_image,
+		    .target_mask = &target,
+		    .effective_size = proto_size,
+		    .tint = {1, 1, 1, 1},
+		    .scale = SCALE_IDENTITY,
+		    .corner_radius = (double)corner_radius,
+		    .max_brightness = 1,
+		};
+		bool ok = backend->ops.blit(backend, (ivec2){0, 0}, proto_mask, &args);
+		pixman_region32_fini(&target);
+		if (!ok) {
+			backend->ops.release_image(backend, proto_mask);
+			return NULL;
+		}
+	}
+	auto atlas =
+	    renderer_shadow_mask_from_shape_mask(r, backend, proto_mask, 0, proto_size);
+	backend->ops.release_image(backend, proto_mask);
+	if (atlas == NULL) {
+		return NULL;
+	}
+	slot->corner_radius = corner_radius;
+	slot->image = atlas;
+	return atlas;
+}
+
+/// Compose a `size`-sized shadow mask from the atlas with nine blits.
+/// `size` is the shadow image size (window size + 2 * shadow radius).
+static image_handle
+renderer_compose_shadow_nine_slice(struct renderer *r, struct backend_base *backend,
+                                   image_handle atlas, unsigned corner_radius, ivec2 size) {
+	// Fixed block: everything within `fixed` of a prototype corner is copied
+	// 1:1; the single-pixel band at offset `fixed` is stretched.
+	int fixed = (int)corner_radius + 2 * r->shadow_radius;
+	int atlas_side = 2 * ((int)corner_radius + r->shadow_radius) + 1 +
+	                 2 * r->shadow_radius;        // proto + 2 * radius
+	assert(fixed * 2 + 1 == atlas_side);
+
+	if (size.width < atlas_side || size.height < atlas_side) {
+		// Too small for slicing; caller falls back to full generation.
+		return NULL;
+	}
+
+	auto out = backend->ops.new_image(backend, BACKEND_IMAGE_FORMAT_MASK, size);
+	if (out == NULL) {
+		return NULL;
+	}
+
+	// Nine pieces: source rect in atlas -> target rect in out. The blit API
+	// expresses "source rect to target rect" as: target region = target rect,
+	// origin = target position of the source image origin, scale = target
+	// extent / source extent (applied around the origin).
+	struct piece {
+		int sx, sy, sw, sh;        // atlas rect
+		int tx, ty, tw, th;        // target rect
+	} pieces[9];
+	int n = 0;
+	int mid_t_w = size.width - 2 * fixed;         // stretched middle width
+	int mid_t_h = size.height - 2 * fixed;        // stretched middle height
+	int right_s = atlas_side - fixed;             // right/bottom fixed block start
+	int right_t_x = size.width - fixed;
+	int bottom_t_y = size.height - fixed;
+
+	// corners (1:1)
+	pieces[n++] = (struct piece){0, 0, fixed, fixed, 0, 0, fixed, fixed};
+	pieces[n++] =
+	    (struct piece){right_s, 0, fixed, fixed, right_t_x, 0, fixed, fixed};
+	pieces[n++] =
+	    (struct piece){0, right_s, fixed, fixed, 0, bottom_t_y, fixed, fixed};
+	pieces[n++] = (struct piece){right_s,   right_s,    fixed, fixed,
+	                             right_t_x, bottom_t_y, fixed, fixed};
+	// edges (stretch one axis)
+	pieces[n++] = (struct piece){fixed, 0, 1, fixed, fixed, 0, mid_t_w, fixed};
+	pieces[n++] =
+	    (struct piece){fixed, right_s, 1, fixed, fixed, bottom_t_y, mid_t_w, fixed};
+	pieces[n++] = (struct piece){0, fixed, fixed, 1, 0, fixed, fixed, mid_t_h};
+	pieces[n++] =
+	    (struct piece){right_s, fixed, fixed, 1, right_t_x, fixed, fixed, mid_t_h};
+	// center (stretch both)
+	pieces[n++] = (struct piece){fixed, fixed, 1, 1, fixed, fixed, mid_t_w, mid_t_h};
+
+	for (int i = 0; i < n; i++) {
+		auto p = &pieces[i];
+		if (p->tw <= 0 || p->th <= 0) {
+			continue;
+		}
+		region_t target;
+		pixman_region32_init_rect(&target, p->tx, p->ty, (unsigned)p->tw,
+		                          (unsigned)p->th);
+		vec2 scale = {.x = (double)p->tw / p->sw, .y = (double)p->th / p->sh};
+		// origin: target coords where the atlas's (0,0) would land, such
+		// that atlas pixel (sx, sy) maps to target (tx, ty) under `scale`
+		// (the blit derives source coords as (target - origin) / scale).
+		ivec2 origin = {
+		    .x = p->tx - (int)((double)p->sx * scale.x),
+		    .y = p->ty - (int)((double)p->sy * scale.y),
+		};
+		struct backend_blit_args args = {
+		    .source_image = atlas,
+		    .target_mask = &target,
+		    .effective_size = {.width = (int)(atlas_side * scale.x),
+		                       .height = (int)(atlas_side * scale.y)},
+		    .tint = {1, 1, 1, 1},
+		    .scale = scale,
+		    .max_brightness = 1,
+		};
+		bool ok = backend->ops.blit(backend, origin, out, &args);
+		pixman_region32_fini(&target);
+		if (!ok) {
+			backend->ops.release_image(backend, out);
+			return NULL;
+		}
+	}
+	return out;
+}
+
 static bool
 renderer_bind_shadow(struct renderer *r, struct backend_base *backend, struct win *w) {
+	auto content_size = win_effective_content_size(w);
 	if (backend->ops.quirks(backend) & BACKEND_QUIRK_SLOW_BLUR) {
 		ivec2 shadow_size;
 		int shadow_stride;
-		uint8_t *shadow_pixels =
-		    make_shadow(backend->c, r->shadow_kernel,
-		                (ivec2){.width = w->widthb, .height = w->heightb},
-		                &shadow_size, &shadow_stride);
+		uint8_t *shadow_pixels = make_shadow(
+		    backend->c, r->shadow_kernel, content_size, &shadow_size, &shadow_stride);
 		if (!shadow_pixels) {
 			log_error("Couldn't generate shadow");
 			return false;
@@ -315,12 +494,41 @@ renderer_bind_shadow(struct renderer *r, struct backend_base *backend, struct wi
 		    shadow_pixels);
 		free(shadow_pixels);
 	} else {
-		if (!w->mask_image && !renderer_bind_mask(r, backend, w)) {
-			return false;
+		auto corner_radius = (unsigned)win_options(w).corner_radius;
+		// The shadow shape only depends on the window outline. If that is a
+		// plain rectangle (note: WMs like i3 stamp rectangular bounding
+		// shapes on ordinary windows, so check the region, not the shaped
+		// flag), compose the shadow from a cached pre-blurred atlas with
+		// nine blits instead of running a full Gaussian over the window
+		// area. Exact for any window at least as large as the prototype.
+		auto shape_extents = pixman_region32_extents(&w->bounding_shape);
+		bool rectangular = pixman_region32_n_rects(&w->bounding_shape) == 1 &&
+		                   shape_extents->x1 == 0 && shape_extents->y1 == 0 &&
+		                   shape_extents->x2 >= content_size.width &&
+		                   shape_extents->y2 >= content_size.height;
+		if (rectangular) {
+			auto atlas = renderer_get_shadow_atlas(r, backend, corner_radius);
+			if (atlas != NULL) {
+				// Shadow image spans the content box + margins; use the
+				// effective content size so the falloff hugs the drawn
+				// decoration during a grow's rebind window.
+				ivec2 shadow_size = {
+				    .width = w->shadow_width - w->widthb + content_size.width,
+				    .height = w->shadow_height - w->heightb + content_size.height,
+				};
+				w->shadow_mask = renderer_compose_shadow_nine_slice(
+				    r, backend, atlas, corner_radius, shadow_size);
+			}
 		}
-		w->shadow_mask = renderer_shadow_mask_from_shape_mask(
-		    r, backend, w->mask_image, win_options(w).corner_radius,
-		    (ivec2){.width = w->widthb, .height = w->heightb});
+		if (w->shadow_mask == NULL) {
+			// Shaped window, tiny window, or atlas failure: full path.
+			if (!w->mask_image && !renderer_bind_mask(r, backend, w)) {
+				return false;
+			}
+			w->shadow_mask = renderer_shadow_mask_from_shape_mask(
+			    r, backend, w->mask_image, win_options(w).corner_radius,
+			    content_size);
+		}
 	}
 	if (!w->shadow_mask) {
 		log_error("Failed to create shadow");

--- a/src/renderer/renderer.c
+++ b/src/renderer/renderer.c
@@ -168,9 +168,23 @@ renderer_set_root_size(struct renderer *r, struct backend_base *backend, ivec2 r
 	return false;
 }
 
+/// The size of the window's rendered content box: its geometry, clamped to
+/// the bound image while a grow's rebind is in flight. Must match the layer
+/// clamp in `layer_from_window` — decoration (shadow, shape mask) is composed
+/// at this size, and win_bind_pending_pixmap releases both when the bound
+/// size changes.
+static inline ivec2 win_effective_content_size(const struct win *w) {
+	ivec2 size = {.width = w->widthb, .height = w->heightb};
+	if (w->win_image_size.width > 0 && w->win_image_size.height > 0) {
+		size.width = min2(size.width, w->win_image_size.width);
+		size.height = min2(size.height, w->win_image_size.height);
+	}
+	return size;
+}
+
 static bool
 renderer_bind_mask(struct renderer *r, struct backend_base *backend, struct win *w) {
-	ivec2 size = {.width = w->widthb, .height = w->heightb};
+	ivec2 size = win_effective_content_size(w);
 	bool succeeded = false;
 	auto image = backend->ops.new_image(backend, BACKEND_IMAGE_FORMAT_MASK, size);
 	if (!image || !backend->ops.clear(backend, image, (struct color){0, 0, 0, 0})) {
@@ -180,6 +194,8 @@ renderer_bind_mask(struct renderer *r, struct backend_base *backend, struct win 
 
 	auto bound_region_local = win_get_bounding_shape_global_by_val(w);
 	pixman_region32_translate(&bound_region_local, -w->g.x, -w->g.y);
+	pixman_region32_intersect_rect(&bound_region_local, &bound_region_local, 0, 0,
+	                               (uint)size.width, (uint)size.height);
 	succeeded = backend->ops.copy_area(backend, (ivec2){0, 0}, (image_handle)image,
 	                                   r->white_image, &bound_region_local);
 	pixman_region32_fini(&bound_region_local);

--- a/src/wm/defs.h
+++ b/src/wm/defs.h
@@ -58,13 +58,16 @@ enum win_flags {
 	WIN_FLAGS_MAPPED = 64,
 	/// this window has properties which needs to be updated
 	WIN_FLAGS_PROPERTY_STALE = 128,
-	// TODO(yshui) _maybe_ split SIZE_STALE into SIZE_STALE and SHAPE_STALE
 	/// this window has an unhandled size/shape change
 	WIN_FLAGS_SIZE_STALE = 256,
 	/// this window has an unhandled position (i.e. x and y) change
 	WIN_FLAGS_POSITION_STALE = 512,
 	/// need better name for this, is set when some aspects of the window changed
 	WIN_FLAGS_FACTOR_CHANGED = 1024,
+	/// this window has an unhandled bounding shape change. Unlike
+	/// WIN_FLAGS_SIZE_STALE this does not invalidate the window pixmap:
+	/// shape only changes which region of the pixmap is drawn.
+	WIN_FLAGS_SHAPE_STALE = 2048,
 };
 
 enum win_script_output {

--- a/src/wm/win.c
+++ b/src/wm/win.c
@@ -494,6 +494,15 @@ void win_bind_pending_pixmap(struct session *ps, struct win *w) {
 
 	log_debug("Binding named pixmap for %#010x (%s) : %#010x", win_id(w), w->name, pixmap);
 
+	if (!ivec2_eq(size, w->win_image_size)) {
+		// The effective decoration size follows the bound content (see
+		// layer_from_window); shadow and shape mask were composed for the
+		// previous size and must be recomposed, or the shadow falloff gets
+		// cropped / corners round at the wrong edges.
+		win_release_shadow(ps->backend_data, w);
+		win_release_mask(ps->backend_data, w);
+	}
+
 	// Must release images first, otherwise breaks NVIDIA driver
 	win_release_pixmap(ps->backend_data, w);
 	w->win_image = ps->backend_data->ops.bind_pixmap(

--- a/src/wm/win.c
+++ b/src/wm/win.c
@@ -508,7 +508,8 @@ void win_process_image_flags(session_t *ps, struct win *w) {
 	// Must release images first, otherwise breaks NVIDIA driver
 	win_release_pixmap(ps->backend_data, w);
 	w->win_image = ps->backend_data->ops.bind_pixmap(
-	    ps->backend_data, pixmap, x_get_visual_info(&ps->c, w->a.visual));
+	    ps->backend_data, pixmap, x_get_visual_info(&ps->c, w->a.visual),
+	    (ivec2){.width = w->widthb, .height = w->heightb});
 	if (!w->win_image) {
 		log_error("Failed to bind pixmap");
 		xcb_free_pixmap(ps->c.c, pixmap);

--- a/src/wm/win.c
+++ b/src/wm/win.c
@@ -468,6 +468,103 @@ void win_process_secondary_flags(session_t *ps, struct win *w) {
 	}
 }
 
+struct win_name_pixmap_request {
+	struct x_async_request_base base;
+	struct session *ps;
+	xcb_window_t wid;
+	xcb_pixmap_t pixmap;
+	/// Window geometry at the time the pixmap was named; that is the size
+	/// of the pixmap regardless of later geometry changes.
+	ivec2 size;
+};
+
+/// Bind `w->pending_pixmap` (already named, size in `w->pending_pixmap_size`)
+/// as the window image, replacing the current one.
+void win_bind_pending_pixmap(struct session *ps, struct win *w) {
+	assert(w->pending_pixmap_ready);
+	auto pixmap = w->pending_pixmap;
+	auto size = w->pending_pixmap_size;
+	w->pending_pixmap = XCB_NONE;
+	w->pending_pixmap_ready = false;
+
+	if (w->state != WSTATE_MAPPED || ps->backend_data == NULL) {
+		xcb_free_pixmap(ps->c.c, pixmap);
+		return;
+	}
+
+	log_debug("Binding named pixmap for %#010x (%s) : %#010x", win_id(w), w->name, pixmap);
+
+	// Must release images first, otherwise breaks NVIDIA driver
+	win_release_pixmap(ps->backend_data, w);
+	w->win_image = ps->backend_data->ops.bind_pixmap(
+	    ps->backend_data, pixmap, x_get_visual_info(&ps->c, w->a.visual), size);
+	if (!w->win_image) {
+		log_error("Failed to bind pixmap");
+		xcb_free_pixmap(ps->c.c, pixmap);
+		win_set_flags(w, WIN_FLAGS_PIXMAP_ERROR);
+		return;
+	}
+	w->win_image_size = size;
+	queue_redraw(ps);
+}
+
+/// Reply handler for the async NameWindowPixmap issued by
+/// `win_process_image_flags`. Binds the new pixmap, or retains the current
+/// window image on failure (same semantics as the old synchronous path).
+static void
+win_handle_name_pixmap_reply(struct x_connection *c, struct x_async_request_base *req_base,
+                             const xcb_raw_generic_event_t *reply_or_error) {
+	auto req = (struct win_name_pixmap_request *)req_base;
+	auto ps = req->ps;
+	auto wid = req->wid;
+	auto pixmap = req->pixmap;
+	auto req_size = req->size;
+	free(req);
+
+	if (reply_or_error == NULL) {
+		// Shutting down
+		return;
+	}
+
+	if (reply_or_error->response_type == 0) {
+		log_debug("Failed to get named pixmap for window %#010x: %s. "
+		          "Retaining its current window image",
+		          wid, x_strerror(c, (xcb_generic_error_t *)reply_or_error));
+		return;
+	}
+
+	auto cursor = wm_find(ps->wm, wid);
+	auto w = cursor != NULL ? wm_ref_deref(cursor) : NULL;
+	if (w == NULL || w->pending_pixmap != pixmap) {
+		// Window gone, or this request was superseded by a newer one
+		// (another size change happened while this was in flight). Free
+		// the orphaned pixmap.
+		xcb_free_pixmap(c->c, pixmap);
+		return;
+	}
+
+	if (w->state != WSTATE_MAPPED || ps->backend_data == NULL) {
+		// Unmapped (or backend reset) while the request was in flight;
+		// the pixmap is no longer interesting.
+		w->pending_pixmap = XCB_NONE;
+		xcb_free_pixmap(c->c, pixmap);
+		return;
+	}
+
+	// Bind immediately. Deferring the bind until the client provably painted
+	// the (possibly grown) pixmap was tried twice and is structurally wrong
+	// for continuous resizes: every new resize step supersedes the request
+	// and resets the proof, so the deferral never converges and the OLD
+	// image stays pinned (frozen content, and a *bigger* transparent gap
+	// because the geometry runs further ahead of the content). Trace
+	// evidence: 800+ request/reset cycles, binds only every ~77ms during a
+	// drag. Fresh content with a briefly-unpainted strip loses to that every
+	// time; the strip is bounded by the client's own paint latency.
+	w->pending_pixmap_size = req_size;
+	w->pending_pixmap_ready = true;
+	win_bind_pending_pixmap(ps, w);
+}
+
 void win_process_image_flags(session_t *ps, struct win *w) {
 	// Assert that the MAPPED flag is already handled.
 	assert(!win_check_flags_all(w, WIN_FLAGS_MAPPED));
@@ -489,32 +586,35 @@ void win_process_image_flags(session_t *ps, struct win *w) {
 	// Image needs to be updated, update it.
 	win_clear_flags(w, WIN_FLAGS_PIXMAP_STALE);
 
-	// Check to make sure the window is still mapped, otherwise we won't be able to
-	// rebind pixmap after releasing it, yet we might still need the pixmap for
-	// rendering.
+	// Acquire the new named pixmap asynchronously. The old synchronous
+	// xcb_request_check here forced a full X round trip per rebind — during
+	// an interactive resize the X server is at its busiest (relaying the
+	// client's configure/damage storm) and the reply could take tens of
+	// milliseconds, stalling the render loop (measured 33-200ms resize
+	// frames). While the request is in flight we keep rendering the current
+	// image, exactly like the old failure path did; the bind happens in the
+	// reply callback.
 	auto pixmap = x_new_id(&ps->c);
-	auto e = xcb_request_check(
-	    ps->c.c, xcb_composite_name_window_pixmap_checked(ps->c.c, win_id(w), pixmap));
-	if (e != NULL) {
-		log_debug("Failed to get named pixmap for window %#010x(%s): %s. "
-		          "Retaining its current window image",
-		          win_id(w), w->name, x_strerror(&ps->c, e));
-		free(e);
-		return;
-	}
+	auto cookie = xcb_composite_name_window_pixmap(ps->c.c, win_id(w), pixmap);
 
-	log_debug("New named pixmap for %#010x (%s) : %#010x", win_id(w), w->name, pixmap);
-
-	// Must release images first, otherwise breaks NVIDIA driver
-	win_release_pixmap(ps->backend_data, w);
-	w->win_image = ps->backend_data->ops.bind_pixmap(
-	    ps->backend_data, pixmap, x_get_visual_info(&ps->c, w->a.visual),
-	    (ivec2){.width = w->widthb, .height = w->heightb});
-	if (!w->win_image) {
-		log_error("Failed to bind pixmap");
-		xcb_free_pixmap(ps->c.c, pixmap);
-		win_set_flags(w, WIN_FLAGS_PIXMAP_ERROR);
+	if (w->pending_pixmap_ready) {
+		// A previously named pixmap was still waiting for client damage;
+		// this newer request supersedes it.
+		xcb_free_pixmap(ps->c.c, w->pending_pixmap);
+		w->pending_pixmap_ready = false;
 	}
+	w->pending_pixmap = pixmap;
+	auto req = ccalloc(1, struct win_name_pixmap_request);
+	req->base = (struct x_async_request_base){
+	    .callback = win_handle_name_pixmap_reply,
+	    .sequence = cookie.sequence,
+	    .no_reply = true,
+	};
+	req->wid = win_id(w);
+	req->pixmap = pixmap;
+	req->ps = ps;
+	req->size = (ivec2){.width = w->widthb, .height = w->heightb};
+	x_await_request(&ps->c, &req->base);
 }
 
 /**
@@ -747,6 +847,11 @@ static inline double win_get_blur_opacity(const struct win *w) {
 /// Doesn't free `w`
 void unmap_win_finish(session_t *ps, struct win *w) {
 	// We are in unmap_win, this window definitely was viewable
+	if (w->pending_pixmap_ready) {
+		xcb_free_pixmap(ps->c.c, w->pending_pixmap);
+		w->pending_pixmap = XCB_NONE;
+		w->pending_pixmap_ready = false;
+	}
 	if (ps->backend_data) {
 		// Only the pixmap needs to be freed and reacquired when mapping.
 		// Shadow image can be preserved.
@@ -1915,26 +2020,45 @@ bool win_process_animation_and_state_change(struct session *ps, struct win *w, d
 	log_debug("Starting animation %s for window %#010x (%s)",
 	          animation_trigger_names[trigger], win_id(w), w->name);
 
-	if (win_check_flags_any(w, WIN_FLAGS_PIXMAP_STALE)) {
-		// Grab the old pixmap, animations might need it
+	if (win_check_flags_any(w, WIN_FLAGS_PIXMAP_STALE) &&
+	    wopts.animations[trigger].output_indices[WIN_SCRIPT_SAVED_IMAGE_BLEND] >= 0) {
+		// Grab the old pixmap, but only if the incoming animation actually
+		// consumes it via saved-image-blend. Capturing costs an image
+		// allocation + copy on NVIDIA and fires on every frame of a
+		// continuous resize; blend-free animations (e.g. crop-reveal
+		// geometry) should not pay it.
+		if (w->saved_win_image != NULL && w->running_animation_instance != NULL &&
+		    w->running_animation.script == wopts.animations[trigger].script) {
+			// Same animation restarting (continuous resize): keep the
+			// original capture and just refresh its scale against the new
+			// geometry. Re-capturing every frame desyncs the blend factor
+			// from the scale, and thrashes allocations on NVIDIA.
+			w->saved_win_image_scale = (vec2){
+			    .x = win_ctx.width / w->saved_win_image_size.width,
+			    .y = win_ctx.height / w->saved_win_image_size.height,
+			};
+			goto captured;
+		}
 		if (w->saved_win_image) {
 			win_release_saved_win_image(ps->backend_data, w);
 		}
+		// The image we save was bound at the previous geometry; on shrink the
+		// current widthb/heightb is smaller, so copy only what exists.
+		ivec2 saved_size = {
+		    .width = (int)win_ctx.width_before,
+		    .height = (int)win_ctx.height_before,
+		};
 		if (ps->drivers & DRIVER_NVIDIA) {
 			// NVIDIA doesn't like us grabbing the new pixmap before releasing
 			// the old one. So we copy the content of the old pixmap so we can
 			// release it.
 			if (w->win_image != NULL) {
 				w->saved_win_image = ps->backend_data->ops.new_image(
-				    ps->backend_data, BACKEND_IMAGE_FORMAT_PIXMAP,
-				    (ivec2){
-				        .width = (int)win_ctx.width_before,
-				        .height = (int)win_ctx.height_before,
-				    });
+				    ps->backend_data, BACKEND_IMAGE_FORMAT_PIXMAP, saved_size);
 				region_t copy_region;
 				pixman_region32_init_rect(&copy_region, 0, 0,
-				                          (uint)win_ctx.width_before,
-				                          (uint)win_ctx.height_before);
+				                          (uint)saved_size.width,
+				                          (uint)saved_size.height);
 				ps->backend_data->ops.copy_area(
 				    ps->backend_data, (ivec2){}, w->saved_win_image,
 				    w->win_image, &copy_region);
@@ -1944,10 +2068,12 @@ bool win_process_animation_and_state_change(struct session *ps, struct win *w, d
 			w->saved_win_image = w->win_image;
 			w->win_image = NULL;
 		}
+		w->saved_win_image_size = saved_size;
 		w->saved_win_image_scale = (vec2){
-		    .x = win_ctx.width / win_ctx.width_before,
-		    .y = win_ctx.height / win_ctx.height_before,
+		    .x = win_ctx.width / saved_size.width,
+		    .y = win_ctx.height / saved_size.height,
 		};
+	captured:;
 	}
 
 	auto new_animation = script_instance_new(wopts.animations[trigger].script);

--- a/src/wm/win.c
+++ b/src/wm/win.c
@@ -362,8 +362,9 @@ void win_process_primary_flags(session_t *ps, struct win *w) {
 		if (win_check_flags_all(w, WIN_FLAGS_SIZE_STALE)) {
 			win_on_win_size_change(w, ps->o.shadow_offset_x,
 			                       ps->o.shadow_offset_y, ps->o.shadow_radius);
-			win_update_bounding_shape(&ps->c, w, ps->o.detect_rounded_corners);
-			win_clear_flags(w, WIN_FLAGS_SIZE_STALE);
+			win_update_bounding_shape(ps, w, ps->o.detect_rounded_corners);
+			// Size change subsumes a pending shape change.
+			win_clear_flags(w, WIN_FLAGS_SIZE_STALE | WIN_FLAGS_SHAPE_STALE);
 
 			// Window shape/size changed, invalidate the images we built
 			// log_trace("free out dated pict");
@@ -377,6 +378,31 @@ void win_process_primary_flags(session_t *ps, struct win *w) {
 		if (win_check_flags_all(w, WIN_FLAGS_POSITION_STALE)) {
 			win_clear_flags(w, WIN_FLAGS_POSITION_STALE);
 		}
+	}
+
+	if (win_check_flags_all(w, WIN_FLAGS_SHAPE_STALE)) {
+		// Shape changed but size didn't: recompute the bounding shape, and
+		// only if it actually differs invalidate derived images (mask,
+		// shadow). The window pixmap is kept either way — its contents are
+		// unaffected by shape changes. i3 and friends re-stamp identical
+		// shapes on every move/resize, so the equality check is what keeps
+		// this storm off the render budget.
+		win_clear_flags(w, WIN_FLAGS_SHAPE_STALE);
+
+		region_t old_shape;
+		pixman_region32_init(&old_shape);
+		pixman_region32_copy(&old_shape, &w->bounding_shape);
+		win_update_bounding_shape(ps, w, ps->o.detect_rounded_corners);
+
+		if (!pixman_region32_equal(&old_shape, &w->bounding_shape)) {
+			win_on_win_size_change(w, ps->o.shadow_offset_x,
+			                       ps->o.shadow_offset_y, ps->o.shadow_radius);
+			win_set_flags(w, WIN_FLAGS_FACTOR_CHANGED);
+			win_release_mask(ps->backend_data, w);
+			win_release_shadow(ps->backend_data, w);
+			ps->pending_updates = true;
+		}
+		pixman_region32_fini(&old_shape);
 	}
 
 	if (win_check_flags_all(w, WIN_FLAGS_PROPERTY_STALE)) {
@@ -1422,8 +1448,78 @@ gen_by_val(win_extents);
  *
  * Mark the window shape as updated
  */
-void win_update_bounding_shape(struct x_connection *c, struct win *w,
-                               bool detect_rounded_corners) {
+struct win_shape_rects_request {
+	struct x_async_request_base base;
+	struct session *ps;
+	xcb_window_t wid;
+	/// Window-body size (widthb/heightb) at request time; a reply for a
+	/// stale size is dropped (a newer request is in flight or coming).
+	ivec2 size;
+};
+
+/// Reply handler for the async ShapeGetRectangles issued by
+/// `win_update_bounding_shape`. Refines the (currently rectangular) bounding
+/// shape with the server's answer.
+static void win_handle_shape_rects_reply(struct x_connection *c attr_unused,
+                                         struct x_async_request_base *req_base,
+                                         const xcb_raw_generic_event_t *reply_or_error) {
+	auto req = (struct win_shape_rects_request *)req_base;
+	auto ps = req->ps;
+	auto wid = req->wid;
+	auto req_size = req->size;
+	free(req);
+
+	if (reply_or_error == NULL || reply_or_error->response_type == 0) {
+		// Shutting down, or window gone.
+		return;
+	}
+
+	auto cursor = wm_find(ps->wm, wid);
+	auto w = cursor != NULL ? wm_ref_deref(cursor) : NULL;
+	if (w == NULL || w->state != WSTATE_MAPPED || w->widthb != req_size.width ||
+	    w->heightb != req_size.height) {
+		// Window gone/unmapped, or it was resized again while the request
+		// was in flight — the rectangles describe a stale size.
+		return;
+	}
+
+	auto r = (const xcb_shape_get_rectangles_reply_t *)reply_or_error;
+	xcb_rectangle_t *xrects =
+	    xcb_shape_get_rectangles_rectangles((xcb_shape_get_rectangles_reply_t *)r);
+	int nrects =
+	    xcb_shape_get_rectangles_rectangles_length((xcb_shape_get_rectangles_reply_t *)r);
+	rect_t *rects = from_x_rects(nrects, xrects);
+
+	region_t br;
+	pixman_region32_init_rects(&br, rects, nrects);
+	free(rects);
+	// Origin correction, see win_update_bounding_shape.
+	pixman_region32_translate(&br, w->g.border_width, w->g.border_width);
+
+	region_t new_shape;
+	pixman_region32_init(&new_shape);
+	win_get_region_local(w, &new_shape);
+	pixman_region32_intersect(&new_shape, &new_shape, &br);
+	pixman_region32_fini(&br);
+
+	if (!pixman_region32_equal(&new_shape, &w->bounding_shape)) {
+		pixman_region32_copy(&w->bounding_shape, &new_shape);
+		if (ps->o.detect_rounded_corners) {
+			w->rounded_corners = win_has_rounded_corners(w);
+		}
+		// Derived images (mask, shadow) were built from the rectangular
+		// interim shape.
+		win_release_mask(ps->backend_data, w);
+		win_release_shadow(ps->backend_data, w);
+		win_set_flags(w, WIN_FLAGS_FACTOR_CHANGED);
+		ps->pending_updates = true;
+		queue_redraw(ps);
+	}
+	pixman_region32_fini(&new_shape);
+}
+
+void win_update_bounding_shape(session_t *ps, struct win *w, bool detect_rounded_corners) {
+	auto c = &ps->c;
 	// We don't handle property updates of non-visible windows until they are
 	// mapped.
 	assert(w->state == WSTATE_MAPPED);
@@ -1432,49 +1528,35 @@ void win_update_bounding_shape(struct x_connection *c, struct win *w,
 	// Start with the window rectangular region
 	win_get_region_local(w, &w->bounding_shape);
 
-	if (c->e.has_shape) {
+	if (c->e.has_shape && !w->shape_known) {
+		// Shapedness only changes via ShapeNotify (which resets
+		// shape_known), never as a side effect of a resize — so the
+		// synchronous ShapeQueryExtents round trip is only needed when we
+		// genuinely don't know. For known-shaped windows the async
+		// rectangles fetch below carries the real shape; re-querying
+		// extents every resize frame cost ~4-6ms against a busy server
+		// (i3 frame windows are shaped, so every i3 resize paid it).
 		w->bounding_shaped = win_bounding_shaped(c, win_id(w));
+		w->shape_known = true;
 	}
 
-	// Only request for a bounding region if the window is shaped
-	// (while loop is used to avoid goto, not an actual loop)
-	while (w->bounding_shaped) {
-		/*
-		 * if window doesn't exist anymore,  this will generate an error
-		 * as well as not generate a region.
-		 */
-
-		xcb_shape_get_rectangles_reply_t *r = xcb_shape_get_rectangles_reply(
-		    c->c, xcb_shape_get_rectangles(c->c, win_id(w), XCB_SHAPE_SK_BOUNDING),
-		    NULL);
-
-		if (!r) {
-			break;
-		}
-
-		xcb_rectangle_t *xrects = xcb_shape_get_rectangles_rectangles(r);
-		int nrects = xcb_shape_get_rectangles_rectangles_length(r);
-		rect_t *rects = from_x_rects(nrects, xrects);
-		free(r);
-
-		region_t br;
-		pixman_region32_init_rects(&br, rects, nrects);
-		free(rects);
-
-		// Add border width because we are using a different origin.
-		// X thinks the top left of the inner window is the origin
-		// (for the bounding shape, although xcb_get_geometry thinks
-		//  the outer top left (outer means outside of the window
-		//  border) is the origin),
-		// We think the top left of the border is the origin
-		pixman_region32_translate(&br, w->g.border_width, w->g.border_width);
-
-		// Intersect the bounding region we got with the window rectangle,
-		// to make sure the bounding region is not bigger than the window
-		// rectangle
-		pixman_region32_intersect(&w->bounding_shape, &w->bounding_shape, &br);
-		pixman_region32_fini(&br);
-		break;
+	if (w->bounding_shaped) {
+		// Fetch the shape rectangles ASYNCHRONOUSLY. The old synchronous
+		// fetch was one X round trip per resize frame per shaped window —
+		// i3 stamps bounding shapes on its frame windows, so this cost
+		// ~5.7ms per hit against a resize-storm-busy server. Until the
+		// reply lands we use the plain window rectangle; for WM frames
+		// (whose shape is the rectangle minus invisible corner slivers)
+		// one interim frame is imperceptible, and the reply path releases
+		// derived images only when the shape actually differs.
+		auto req = ccalloc(1, struct win_shape_rects_request);
+		req->base.sequence =
+		    xcb_shape_get_rectangles(c->c, win_id(w), XCB_SHAPE_SK_BOUNDING).sequence;
+		req->base.callback = win_handle_shape_rects_reply;
+		req->ps = ps;
+		req->wid = win_id(w);
+		req->size = (ivec2){.width = w->widthb, .height = w->heightb};
+		x_await_request(c, &req->base);
 	}
 
 	if (w->bounding_shaped && detect_rounded_corners) {

--- a/src/wm/win.c
+++ b/src/wm/win.c
@@ -299,6 +299,14 @@ static void win_update_properties(session_t *ps, struct win *w) {
 		}
 	}
 
+	if (win_fetch_and_unset_property_stale(w, ps->atoms->a_NET_WM_BYPASS_COMPOSITOR)) {
+		bool bypass = win_fetch_bypassing_compositor(ps, w);
+		if (bypass != w->is_bypassing_compositor) {
+			w->is_bypassing_compositor = bypass;
+			win_set_flags(w, WIN_FLAGS_FACTOR_CHANGED);
+		}
+	}
+
 	if (ps->o.track_leader &&
 	    (win_fetch_and_unset_property_stale(w, ps->atoms->aWM_CLIENT_LEADER) ||
 	     win_fetch_and_unset_property_stale(w, ps->atoms->aWM_TRANSIENT_FOR) ||
@@ -1448,7 +1456,7 @@ struct win *win_maybe_allocate(session_t *ps, struct wm_ref *cursor,
 	    ps->atoms->a_NET_WM_NAME,        ps->atoms->aWM_CLASS,
 	    ps->atoms->aWM_WINDOW_ROLE,      ps->atoms->a_COMPTON_SHADOW,
 	    ps->atoms->aWM_CLIENT_LEADER,    ps->atoms->aWM_TRANSIENT_FOR,
-	    ps->atoms->a_NET_WM_STATE,
+	    ps->atoms->a_NET_WM_STATE,       ps->atoms->a_NET_WM_BYPASS_COMPOSITOR,
 	};
 	win_set_properties_stale(new, init_stale_props, ARR_SIZE(init_stale_props));
 	c2_window_state_init(ps->c2_state, &new->c2_state);
@@ -2387,11 +2395,12 @@ void win_update_is_fullscreen(const session_t *ps, struct win *w) {
 }
 
 /**
- * Check if a window has BYPASS_COMPOSITOR property set
+ * Fetch the BYPASS_COMPOSITOR property from the X server.
  *
- * TODO(yshui) cache this property
+ * Synchronous; used only when the cached value is (re)established — see
+ * `win_is_bypassing_compositor` for the cached read used in the frame path.
  */
-bool win_is_bypassing_compositor(const session_t *ps, const struct win *w) {
+bool win_fetch_bypassing_compositor(const session_t *ps, const struct win *w) {
 	bool ret = false;
 	auto wid = win_client_id(w, /*fallback_to_self=*/true);
 
@@ -2404,4 +2413,12 @@ bool win_is_bypassing_compositor(const session_t *ps, const struct win *w) {
 
 	free_winprop(&prop);
 	return ret;
+}
+
+/**
+ * Check if a window has BYPASS_COMPOSITOR property set, from the cache
+ * maintained by the PropertyNotify stale machinery. No X round trip.
+ */
+bool win_is_bypassing_compositor(const session_t *ps attr_unused, const struct win *w) {
+	return w->is_bypassing_compositor;
 }

--- a/src/wm/win.h
+++ b/src/wm/win.h
@@ -237,6 +237,10 @@ struct win {
 
 	/// Number of times each animation trigger is blocked
 	unsigned int animation_block[ANIMATION_TRIGGER_COUNT];
+	/// Cached _NET_WM_BYPASS_COMPOSITOR == 1, maintained by the
+	/// PropertyNotify stale machinery. Read per frame; fetching it
+	/// synchronously would cost an X round trip per rules re-evaluation.
+	bool is_bypassing_compositor;
 	/// Whether `bounding_shaped` reflects an actual ShapeQueryExtents
 	/// answer. Reset by ShapeNotify; lets pure size changes of never-shaped
 	/// windows skip the shape queries (an X round trip per resize frame).
@@ -462,6 +466,7 @@ void win_update_is_fullscreen(const session_t *ps, struct win *w);
  * Check if a window has BYPASS_COMPOSITOR property set
  */
 bool win_is_bypassing_compositor(const session_t *ps, const struct win *w);
+bool win_fetch_bypassing_compositor(const session_t *ps, const struct win *w);
 /**
  * Get a rectangular region in global coordinates a window (and possibly
  * its shadow) occupies.

--- a/src/wm/win.h
+++ b/src/wm/win.h
@@ -91,12 +91,20 @@ struct win {
 	/// backend data attached to this window. Only available when
 	/// `state` is not UNMAPPED
 	image_handle win_image;
+	/// Pixel size of `win_image`. With asynchronous pixmap binding the
+	/// window geometry can run ahead of the bound image (the new pixmap is
+	/// still in flight); the renderer must not paint the old image beyond
+	/// its actual extent (the window sampler repeats, which would tile it).
+	ivec2 win_image_size;
 	/// The old window image before the window image is refreshed. This is used for
 	/// animation, and is only kept alive for the duration of the animation.
 	image_handle saved_win_image;
 	/// How much to scale the saved_win_image, so that it is the same size as the
 	/// current window image.
 	vec2 saved_win_image_scale;
+	/// Pixel size of saved_win_image at capture time. Used to recompute the
+	/// scale on animation restarts without re-capturing.
+	ivec2 saved_win_image_size;
 	/// A mask image for the shadow. This is usually a blurred `mask_image`, though
 	/// for some backends this can be generated on the CPU.
 	image_handle shadow_mask;
@@ -233,6 +241,18 @@ struct win {
 	/// answer. Reset by ShapeNotify; lets pure size changes of never-shaped
 	/// windows skip the shape queries (an X round trip per resize frame).
 	bool shape_known;
+	/// The named pixmap we have requested asynchronously but not yet bound.
+	/// A newer request supersedes an in-flight one (the reply handler frees
+	/// the orphaned pixmap when the recorded id doesn't match).
+	xcb_pixmap_t pending_pixmap;
+	/// True when `pending_pixmap` has been named successfully. Kept only for
+	/// win_bind_pending_pixmap's precondition; NOTE: deferring the bind
+	/// until the client paints was tried (twice) and does not work —
+	/// continuous resizes supersede the request before any paint-proof can
+	/// complete, pinning a stale image. Bind immediately.
+	bool pending_pixmap_ready;
+	/// Pixel size of the ready `pending_pixmap`.
+	ivec2 pending_pixmap_size;
 };
 
 struct win_script_context {
@@ -408,6 +428,9 @@ double win_animatable_get(const struct win *w, enum win_script_output output);
 void win_process_primary_flags(session_t *ps, struct win *w);
 void win_process_secondary_flags(session_t *ps, struct win *w);
 void win_process_image_flags(session_t *ps, struct win *w);
+/// Bind the named `pending_pixmap` as the window image (see
+/// `pending_pixmap_ready`).
+void win_bind_pending_pixmap(session_t *ps, struct win *w);
 
 /// Start the unmap of a window. We cannot unmap immediately since we might need to fade
 /// the window out.

--- a/src/wm/win.h
+++ b/src/wm/win.h
@@ -229,6 +229,10 @@ struct win {
 
 	/// Number of times each animation trigger is blocked
 	unsigned int animation_block[ANIMATION_TRIGGER_COUNT];
+	/// Whether `bounding_shaped` reflects an actual ShapeQueryExtents
+	/// answer. Reset by ShapeNotify; lets pure size changes of never-shaped
+	/// windows skip the shape queries (an X round trip per resize frame).
+	bool shape_known;
 };
 
 struct win_script_context {
@@ -541,8 +545,7 @@ int win_update_role(struct x_connection *c, struct atom *atoms, struct win *w);
 int win_update_name(struct x_connection *c, struct atom *atoms, struct win *w);
 void win_on_win_size_change(struct win *w, int shadow_offset_x, int shadow_offset_y,
                             int shadow_radius);
-void win_update_bounding_shape(struct x_connection *c, struct win *w,
-                               bool detect_rounded_corners);
+void win_update_bounding_shape(session_t *ps, struct win *w, bool detect_rounded_corners);
 bool win_update_prop_fullscreen(struct x_connection *c, const struct atom *atoms,
                                 struct win *w);
 


### PR DESCRIPTION
## Summary

This series removes the synchronous X round trips from the interactive
resize path. Each round trip blocked the render loop while it waited for
the X server. The X server answers slowest during a resize, because it
also relays the configure and damage storm of the client. On my setup
this made resize feel like a slideshow: 10-16fps, with single frames
that took 33ms to 200ms.

### What it looked like before

These are the visible symptoms this series fixes, on `next`, during a
normal mouse resize:

- **Low frame rate.** The compositor spent most of each frame inside
  blocking waits, not rendering. Dragging a corner produced visible
  steps instead of smooth motion.
- **Transparent strips on grow.** When a window grew, the new strip on
  the right and bottom edges rendered as fully transparent for a few
  frames. The desktop showed through inside the window border until the
  client painted the new area.
- **Tiled garbage on grow.** In other cases the same strip showed a copy
  of stale window content repeated like floor tiles. The sampler wrapped
  around the old, smaller texture (GL_REPEAT), so the strip filled with
  repeated fragments of the window instead of transparency.
- **Shadow and corner glitches.** The shadow was rebuilt with a full
  Gaussian blur on every size change. During a resize this either
  cropped the shadow falloff or rounded the corners at the wrong edges
  for a frame.

The fixes: bind window pixmaps asynchronously and keep rendering the
current image while the request is in flight. Never draw a window beyond
its bound image, so decoration (border, shadow, corners) hugs real
pixels instead of a not-yet-painted area. Sample window content with
edge-clamp semantics, so out-of-bounds sampling repeats the edge pixel
instead of tiling the texture. Compose shadows for rectangular windows
from a cached nine-slice atlas instead of a full blur per size change.
Each commit message has the full rationale.

### Round trips removed

Costs are per frame, measured with tracing during an interactive resize
on the setup below. The old paths blocked once per affected window, so
the costs multiply with the window count.

| Synchronous round trip | Trigger during resize | Measured cost | Now |
|---|---|---|---|
| `ShapeQueryExtents` + `ShapeGetRectangles` | i3 sends a ShapeNotify to every frame window on every resize step | 2-4ms x 8 windows = 29-44ms per step | Read the `shaped` flag from the event. Fetch the rectangles async. |
| `xcb_get_geometry` at pixmap bind | Every pixmap rebind | One round trip per rebind | The caller passes the size it already knows. |
| `xcb_request_check` on `NameWindowPixmap` | Every size change | The largest stall. Resize frames of 33-200ms. | Async request. The reply handler binds the pixmap. |
| `XFixesFetchRegion` per DamageNotify | Every client repaint | One round trip per damage event | Async fetch into the damaged region. |
| `GetProperty` refetches (c2 rules, window title) | Terminals stamp the title on every resize step | Several ms per fetch under load | Async fetch on PropertyNotify. |
| Full shadow blur on size change | Every resize frame per shadowed window | Several ms per window | Nine-slice atlas compose, 0.1ms. |

### Performance

Same machine, same config, same interactive drag-resize workload.
Setup: 4-monitor NVIDIA (RTX 5080), 240Hz primary, i3, EGL backend.

| Metric | `next` | This series |
|---|---|---|
| Sustained fps during drag-resize | 10-16 | 100-120 |
| Frame time, median | 33-200ms | 8-10ms |
| Frame time, p95 | - | 11-14ms |
| Shadow rebind on a resize frame | several ms | 0.1ms |
| Transparent strips / tiled garbage on grow | present | fixed |

### Notes for review

The last two commits are separable. The Present-scheduler and
non-blocking-swap default change has escape hatches via `PICOM_DEBUG`.
I can drop it or gate it differently if you prefer. The final commit is
#1523 by @0x041E, cherry-picked with attribution. Rounded corners are
redrawn heavily during resize, so it belongs in this set. It drops out
on rebase if #1523 merges first.

## Checklist

- [x] Enable "Allow edits from maintainers". (So we can make necessary changes).
- [x] Add changelog entries to commit messages when appropriate. These will be included in release announcements.
