### PR TITLE
wm: make dim an animatable property

### DIFF
--- a/man/picom.1.adoc
+++ b/man/picom.1.adoc
@@ -539,6 +539,8 @@ animations = ({
 
 	  _color_:: When some color property of a window is changed. Right now this only includes _shadow-color_.
 
+  _dim_:: When the dim level of a window is changed, e.g. when a window loses or gains focus with _inactive-dim_ set.
+
 	  [[trigger-geometry]]_geometry_:: Alias of size + position.
 +
 WARNING: The _size_ and _position_ triggers are experimental. Using this means you accept the caveat that these animations will also trigger when you manually resize or move a window, like when you drag the window around with your mouse.
@@ -737,6 +739,8 @@ Currently, these output variables are supported: :::
 
   _shadow-red_, _shadow-green_, _shadow-blue_:: Color of the shadow. Each component is specified separately, each number is between 0 and 1.
 
+  _dim_:: How much the window is dimmed. This is a number between 0 and 1, where 0 means not dimmed at all.
+
   _scale-x_, _scale-y_, _shadow-scale-x_, _shadow-scale-y_:: The scaling factor of the window and shadow in the X and Y direction, respectively. 1.0 means no scaling. The window body and the shadow are scaled independently. When they are scaled, the scale origin will be the top-left corner of the window, for *both* of them.
 
   _crop-x_, _crop-y_, _crop-width_, _crop-height_:: These four values combined defines a rectangle on the screen. The window and its shadow will be cropped to this rectangle. If not defined, the window and shadow will not be cropped.
@@ -774,6 +778,8 @@ Currently, these context variables are defined: :::
   _window-blur-opacity-before_, _window-blur-opacity_:: The blur opacity of the window for the previous and current frame.
 
   _window-shadow-red_, _window-shadow-green_, _window-shadow-blue_, _window-shadow-red-before_, _window-shadow-green-before_, _window-shadow-blue-before_:: Color of the shadow before and after the shadow color change. (See notes below about _window-*-before_ variables.
+
+  _window-dim-before_, _window-dim_:: The dim level of the window for the previous and current frame. (See notes below about _window-*-before_ variables.)
 
 IMPORTANT: All of the _window-*-before_ variables are updated every frame, and reflects the state of the window in the previous frame. Which means they will only be meaningful for a single frame, when an animation has just been triggered. Which means you should only use them to define the _start_, _end_, _duration_, or _delay_ values of a timing function, since these values are only evaluated once when the animation starts.
 --

--- a/src/config.h
+++ b/src/config.h
@@ -81,6 +81,8 @@ enum animation_trigger {
 	/// When one of a window's color properties changes,
 	/// This includes: shadow-color
 	ANIMATION_TRIGGER_COLOR,
+	/// When a window's dim level changes
+	ANIMATION_TRIGGER_DIM,
 
 	ANIMATION_TRIGGER_INVALID,
 	ANIMATION_TRIGGER_COUNT = ANIMATION_TRIGGER_INVALID,
@@ -101,6 +103,7 @@ static const char *animation_trigger_names[] attr_unused = {
     [ANIMATION_TRIGGER_SIZE] = "size",
     [ANIMATION_TRIGGER_POSITION] = "position",
     [ANIMATION_TRIGGER_COLOR] = "color",
+    [ANIMATION_TRIGGER_DIM] = "dim",
     [ANIMATION_TRIGGER_ALIAS_GEOMETRY] = "geometry",
 };
 

--- a/src/renderer/layout.c
+++ b/src/renderer/layout.c
@@ -101,6 +101,7 @@ static bool layer_from_window(struct layer *out_layer, struct win *w, ivec2 size
 	}
 
 	out_layer->opacity = (float)win_animatable_get(w, WIN_SCRIPT_OPACITY);
+	out_layer->options.dim = win_animatable_get(w, WIN_SCRIPT_DIM);
 	out_layer->blur_opacity =
 	    (float)clamp(win_animatable_get(w, WIN_SCRIPT_BLUR_OPACITY), 0., 1.);
 	out_layer->shadow_color.red = (float)win_animatable_get(w, WIN_SCRIPT_SHADOW_RED);

--- a/src/wm/defs.h
+++ b/src/wm/defs.h
@@ -106,6 +106,8 @@ enum win_script_output {
 	WIN_SCRIPT_SHADOW_GREEN,
 	/// Ditto
 	WIN_SCRIPT_SHADOW_BLUE,
+	/// Dim level of this window
+	WIN_SCRIPT_DIM,
 
 	NUM_OF_WIN_SCRIPT_OUTPUTS,
 };

--- a/src/wm/win.c
+++ b/src/wm/win.c
@@ -1624,6 +1624,8 @@ win_script_context_prepare(struct session *ps, struct win *w) {
 	    .monitor_height = monitor.y2 - monitor.y1,
 	    .shadow_color_before = w->previous.shadow_color,
 	    .shadow_color = w->options.shadow_color,
+	    .dim = win_options(w).dim,
+	    .dim_before = w->previous.dim,
 	};
 	return ret;
 }
@@ -1655,6 +1657,7 @@ double win_animatable_get(const struct win *w, enum win_script_output output) {
 	case WIN_SCRIPT_SHADOW_RED: return wopts.shadow_color.red;
 	case WIN_SCRIPT_SHADOW_GREEN: return wopts.shadow_color.green;
 	case WIN_SCRIPT_SHADOW_BLUE: return wopts.shadow_color.blue;
+	case WIN_SCRIPT_DIM: return wopts.dim;
 	default: unreachable();
 	}
 	unreachable();
@@ -1712,6 +1715,7 @@ bool win_process_animation_and_state_change(struct session *ps, struct win *w, d
 	w->previous.opacity = w->opacity;
 	w->previous.g = w->g;
 	w->previous.shadow_color = w->options.shadow_color;
+	w->previous.dim = win_options(w).dim;
 	w->previous.blur_opacity = win_get_blur_opacity(w);
 
 	if (!ps->redirected || will_never_render) {
@@ -1796,6 +1800,9 @@ bool win_process_animation_and_state_change(struct session *ps, struct win *w, d
 	} else if (!color_eq(win_ctx.shadow_color_before, win_ctx.shadow_color)) {
 		assert(w->state == WSTATE_MAPPED);
 		trigger = ANIMATION_TRIGGER_COLOR;
+	} else if (win_ctx.dim_before != win_ctx.dim) {
+		assert(w->state == WSTATE_MAPPED);
+		trigger = ANIMATION_TRIGGER_DIM;
 	}
 
 	if (trigger == ANIMATION_TRIGGER_INVALID) {

--- a/src/wm/win.h
+++ b/src/wm/win.h
@@ -83,6 +83,7 @@ struct win_state_change {
 	double blur_opacity;
 	struct win_geometry g;
 	struct color shadow_color;
+	double dim;
 };
 
 struct win {
@@ -239,6 +240,7 @@ struct win_script_context {
 	double monitor_x, monitor_y;
 	double monitor_width, monitor_height;
 	struct color shadow_color, shadow_color_before;
+	double dim, dim_before;
 };
 // NOLINTNEXTLINE(bugprone-sizeof-expression)
 static_assert(SCRIPT_CTX_PLACEHOLDER_BASE > sizeof(struct win_script_context),
@@ -268,6 +270,8 @@ static const struct script_context_info win_script_context_info[] = {
     {"window-shadow-red-before", X(shadow_color_before.red)},
     {"window-shadow-green-before", X(shadow_color_before.green)},
     {"window-shadow-blue-before", X(shadow_color_before.blue)},
+    {"window-dim", X(dim)},
+    {"window-dim-before", X(dim_before)},
     {NULL, 0}        //
 };
 #undef X
@@ -292,6 +296,7 @@ static const struct script_output_info win_script_outputs[] = {
     [WIN_SCRIPT_SHADOW_RED] = {"shadow-red"},
     [WIN_SCRIPT_SHADOW_GREEN] = {"shadow-green"},
     [WIN_SCRIPT_SHADOW_BLUE] = {"shadow-blue"},
+    [WIN_SCRIPT_DIM] = {"dim"},
     [NUM_OF_WIN_SCRIPT_OUTPUTS] = {NULL},
 };
 


### PR DESCRIPTION
## Summary

Closes #861, closes #414.

`dim` is assigned directly in `win_update_dim()` (`src/wm/win.c:748-752`), so it
snaps by construction:

```c
if (ps->o.inactive_dim > 0 && !focused) {
        w->options.dim = ps->o.inactive_dim;
} else {
        w->options.dim = 0;
}
```

This makes `dim` an animatable property with its own trigger, following the
pattern `ANIMATION_TRIGGER_COLOR` established for `shadow-color`. 24 lines,
including the man page.

`src/renderer/command_builder.c` is untouched: `layer_from_window()` copies
`w_opts` then overrides animated fields individually, so the existing
`layer->options.dim` read picks up the animated value from one added line in
`layout.c`. `SCRIPT_CTX_PLACEHOLDER_BASE` absorbs the two extra doubles with
room to spare.

Usage:

```
animations = ({
    triggers = ["dim"];
    dim = {
        curve = "cubic-bezier(0.25, 0.1, 0.25, 1.0)";
        duration = 0.35;
        start = "window-dim-before";
        end = "window-dim";
    };
});
```

### Testing

Sampled the composited root window at a fixed pixel on a `#ff0000` window
losing focus, with `inactive-dim = 0.12`. Same binary, same config, only the
animation block differs:

| t | with `dim` animation | without |
|---|---|---|
| baseline | 255 | 255 |
| +050ms | 255 | 255 |
| +100ms | 251 | **224** |
| +150ms | 239 | 224 |
| +200ms | 232 | 224 |
| +250ms | 227 | 224 |
| +300ms | 225 | 224 |
| +350ms | 224 | 224 |

224/255 = 0.878, matching `inactive-dim = 0.12`, and the ramp follows the
specified easing curve. The control snaps in a single frame.

Parsing was checked as a control pair, since picom does not warn on unknown
config keys: `triggers = ["dim"]` is accepted silently, a deliberate
`["dimmm"]` errors with `Invalid trigger defined at line 4`, and v13 rejects
both the trigger and the `window-dim-before` variable.

Tested on X11 / glx / NVIDIA. **I have not tested the xrender backend.**

### Questions

1. **Separate trigger, or fold into `ANIMATION_TRIGGER_COLOR`?** I kept it
   separate since dim is a scalar rather than a color property, and it likely
   wants its own duration — but COLOR is already documented as a catch-all,
   so folding it in is defensible.
2. **Position in the `else if` chain.** I put `dim` last, so a simultaneous
   opacity change wins and dim will not animate. That is reachable with
   `active-opacity`/`inactive-opacity` set, since both change on the same
   focus event. Is one trigger per frame the intended model, or should dim be
   checked earlier?
3. Should `dim` also be settable as a rule-level animation, or is the global
   `animations` block enough for a first cut?

Happy to restructure any of this.

## Checklist

- [x] Enable "Allow edits from maintainers".
- [x] Add changelog entries to commit messages when appropriate.